### PR TITLE
Add move get-previous-version from e2e to here.

### DIFF
--- a/.github/actions/get-previous-version/action.yml
+++ b/.github/actions/get-previous-version/action.yml
@@ -1,0 +1,89 @@
+name: Get Previous Weaviate Version
+description: "Gets a previous version of Weaviate based on specified criteria"
+
+inputs:
+  weaviate_version:
+    required: true
+    description: "Current Weaviate version"
+  jump_type:
+    required: true
+    description: "Type of version jump (patch/minor)"
+    default: 'patch'
+  jumps:
+    required: false
+    description: "Number of versions to jump back"
+    default: '1'
+
+outputs:
+  previous_version:
+    description: "Previous Weaviate version"
+    value: ${{ steps.get-prev-version.outputs.version }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
+
+    - name: Install Dependencies
+      shell: bash
+      run: pip install requests semver
+
+    - name: Get Previous Version
+      id: get-prev-version
+      shell: python
+      run: |
+        import requests
+        import semver
+        import os
+
+        def get_versions():
+            response = requests.get('https://api.github.com/repos/weaviate/weaviate/releases?per_page=100')
+            releases = response.json()
+            versions = []
+
+            for release in releases:
+                tag = release['tag_name']
+                try:
+                    if tag.startswith('v'):
+                        ver = semver.VersionInfo.parse(tag[1:])
+                        if ver.prerelease is None:
+                            versions.append(ver)
+                except ValueError:
+                    continue
+
+            return sorted(versions, reverse=True)
+
+        def get_previous_version(current_version, jump_type='patch', jumps=1):
+            versions = get_versions()
+
+            if jump_type == 'patch':
+                # Get all versions with same major and minor, sorted in descending order
+                prev_versions = [v for v in versions if v < current_version and
+                               v.major == current_version.major and
+                               v.minor == current_version.minor]
+                # Return the version that's 'jumps' steps back from the current version
+                if len(prev_versions) >= jumps:
+                    return prev_versions[jumps - 1]
+            else:  # jump_type == 'minor'
+                target_minor = current_version.minor - jumps
+                prev_versions = [v for v in versions if
+                               v.major == current_version.major and
+                               v.minor == target_minor]
+                if prev_versions:
+                    return prev_versions[0]
+            return None
+
+        current = semver.VersionInfo.parse('${{ inputs.weaviate_version }}'.lstrip('v'))
+        prev_version = get_previous_version(current, '${{ inputs.jump_type }}', int('${{ inputs.jumps }}'))
+
+        if prev_version:
+            result = f"{prev_version}"
+            print(f"Previous version: {result}")
+            with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+                f.write(f"version={result}\n")
+        else:
+            print("No matching version found")
+            exit(1)

--- a/.github/workflows/previous-version-test.yml
+++ b/.github/workflows/previous-version-test.yml
@@ -1,0 +1,89 @@
+name: Test Get Previous Version Action
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+        LATEST_124_VERSION: '1.24.26' # Update this when the latest 1.24.x version is released
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Test patch version jump
+        uses: ./.github/actions/get-previous-version
+        id: test-patch
+        with:
+          weaviate_version: '1.24.21'
+          jump_type: 'patch'
+
+      - name: Verify patch output
+        run: |
+          if [ "${{ steps.test-patch.outputs.previous_version }}" != "1.24.20" ]; then
+            echo "Expected version 1.24.20, got ${{ steps.test-patch.outputs.previous_version }}"
+            exit 1
+          fi
+
+      - name: Test multiple patch version jumps
+        uses: ./.github/actions/get-previous-version
+        id: test-patch-multiple
+        with:
+          weaviate_version: '1.24.21'
+          jump_type: 'patch'
+          jumps: '3'
+
+      - name: Verify patch output
+        run: |
+          if [ "${{ steps.test-patch-multiple.outputs.previous_version }}" != "1.24.18" ]; then
+            echo "Expected version 1.24.18, got ${{ steps.test-patch-multiple.outputs.previous_version }}"
+            exit 1
+          fi
+
+      - name: Test minor version jump
+        uses: ./.github/actions/get-previous-version
+        id: test-minor
+        with:
+          weaviate_version: '1.25.21'
+          jump_type: 'minor'
+          jumps: '1'
+
+      - name: Verify minor output
+        run: |
+          if [ "${{ steps.test-minor.outputs.previous_version }}" != "$LATEST_124_VERSION" ]; then
+            echo "Expected version $LATEST_124_VERSION, got ${{ steps.test-minor.outputs.previous_version }}"
+            exit 1
+          fi
+
+      - name: Test multiple minor jumps
+        uses: ./.github/actions/get-previous-version
+        id: test-multiple
+        with:
+          weaviate_version: '1.26.17'
+          jump_type: 'minor'
+          jumps: '2'
+
+      - name: Verify multiple jumps output
+        run: |
+          if [ "${{ steps.test-multiple.outputs.previous_version }}" != "$LATEST_124_VERSION" ]; then
+            echo "Expected version $LATEST_124_VERSION, got ${{ steps.test-multiple.outputs.previous_version }}"
+            exit 1
+          fi
+
+      - name: Test with invalid version
+        uses: ./.github/actions/get-previous-version
+        id: test-invalid
+        continue-on-error: true
+        with:
+          weaviate_version: '0.0.0'
+          jump_type: 'patch'
+
+      - name: Verify invalid version fails
+        run: |
+          if [ "${{ steps.test-invalid.outcome }}" != "failure" ]; then
+            echo "Expected action to fail with invalid version"
+            exit 1
+          fi 

--- a/README.md
+++ b/README.md
@@ -78,8 +78,62 @@ jobs:
 ```
 
 
+## get-previous-version
 
+### Description
+Retrieves a previous version of Weaviate based on specified criteria, allowing for patch or minor version jumps.
 
+### Inputs
+- `weaviate_version` (required): The current Weaviate version to start from
+- `jump_type` (required): Type of version jump to perform
+  - `patch`: Get the previous patch version within the same minor version
+  - `minor`: Get a version from a previous minor version
+- `jumps` (optional): Number of minor versions to jump back when `jump_type` is 'minor'. Default: '1'
 
+### Outputs
+- `previous_version`: The previous Weaviate version based on the specified criteria
 
+### Usage
+```yaml
+name: Get Previous Weaviate Version
+on: [push]
+
+jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Get Previous Patch Version
+        uses: weaviate/github-common-actions/.github/actions/get-previous-version@main
+        id: get-version
+        with:
+          weaviate_version: '1.24.21'
+          jump_type: 'patch'
+
+      - name: Get Previous Minor Version
+        uses: weaviate/github-common-actions/.github/actions/get-previous-version@main
+        id: get-minor-version
+        with:
+          weaviate_version: '1.25.21'
+          jump_type: 'minor'
+          jumps: '1'
+
+      - name: Output Versions
+        run: |
+          echo "Previous patch version: ${{ steps.get-version.outputs.previous_version }}"
+          echo "Previous minor version: ${{ steps.get-minor-version.outputs.previous_version }}"
+```
+
+### Examples
+- For version `1.24.21` with `jump_type: 'patch'` → returns `1.24.20`
+- For version `1.25.21` with `jump_type: 'minor'` and `jumps: '1'` → returns latest `1.24.x` version
+- For version `1.26.17` with `jump_type: 'minor'` and `jumps: '2'` → returns latest `1.24.x` version
+
+### Runs
+This action runs using `composite` with the following steps:
+1. **Set up Python**: Sets up Python 3.11 environment
+2. **Install Dependencies**: Installs required Python packages (requests, semver)
+3. **Get Previous Version**: Fetches available versions from GitHub releases and returns the appropriate previous version based on the specified criteria
 


### PR DESCRIPTION
This github action can be pretty handy also in other Github Workflows, so moving it here.
It basically returns the latest available version of weaviate by minor version or patch version jumps. You can either jump one or more times.
This is very helpful in upgrades jobs for example, where the latest version can be moving.