### PR TITLE
retry fetching versions from github

### DIFF
--- a/.github/actions/get-previous-version/action.yml
+++ b/.github/actions/get-previous-version/action.yml
@@ -40,7 +40,13 @@ runs:
         import os
 
         def get_versions():
-            response = requests.get('https://api.github.com/repos/weaviate/weaviate/releases?per_page=100')
+            for attempts in range(5):
+                response = requests.get('https://api.github.com/repos/weaviate/weaviate/releases?per_page=100')
+                if response.status_code == 200:
+                    break
+                time.sleep(2**attempts)
+            if response.status_code != 200:
+                raise Exception(f"Failed to fetch releases: {response.status_code} Body: {response.json()}")
             releases = response.json()
             versions = []
 

--- a/.github/workflows/previous-version-test.yml
+++ b/.github/workflows/previous-version-test.yml
@@ -18,13 +18,13 @@ jobs:
         uses: ./.github/actions/get-previous-version
         id: test-patch
         with:
-          weaviate_version: '1.24.21'
+          weaviate_version: '1.24.25'
           jump_type: 'patch'
 
       - name: Verify patch output
         run: |
-          if [ "${{ steps.test-patch.outputs.previous_version }}" != "1.24.20" ]; then
-            echo "Expected version 1.24.20, got ${{ steps.test-patch.outputs.previous_version }}"
+          if [ "${{ steps.test-patch.outputs.previous_version }}" != "1.24.24" ]; then
+            echo "Expected version 1.24.24, got ${{ steps.test-patch.outputs.previous_version }}"
             exit 1
           fi
 
@@ -32,14 +32,14 @@ jobs:
         uses: ./.github/actions/get-previous-version
         id: test-patch-multiple
         with:
-          weaviate_version: '1.24.21'
+          weaviate_version: '1.24.25'
           jump_type: 'patch'
           jumps: '3'
 
       - name: Verify patch output
         run: |
-          if [ "${{ steps.test-patch-multiple.outputs.previous_version }}" != "1.24.18" ]; then
-            echo "Expected version 1.24.18, got ${{ steps.test-patch-multiple.outputs.previous_version }}"
+          if [ "${{ steps.test-patch-multiple.outputs.previous_version }}" != "1.24.22" ]; then
+            echo "Expected version 1.24.22, got ${{ steps.test-patch-multiple.outputs.previous_version }}"
             exit 1
           fi
 


### PR DESCRIPTION
This should retry our GET call to github for releases so hopefully we fail less, and when we do fail it should give us a more straight forward error.

tests running here https://github.com/weaviate/weaviate-e2e-tests/actions/runs/14869759794
