### PR TITLE
Revert "[fix] use github auth with get version to avoid rate limits"

### DIFF
--- a/.github/actions/get-previous-version/action.yml
+++ b/.github/actions/get-previous-version/action.yml
@@ -5,9 +5,6 @@ inputs:
   weaviate_version:
     required: true
     description: "Current Weaviate version"
-  gh_token:
-    required: true
-    description: "should be secrets.GITHUB_TOKEN , but the parent job has to pass it"
   jump_type:
     required: true
     description: "Type of version jump (patch/minor)"
@@ -44,9 +41,8 @@ runs:
         import os
 
         def get_versions():
-            auth_header={"Authorization": f"Bearer ${{ inputs.gh_token }}"}
             for attempts in range(5):
-                response = requests.get('https://api.github.com/repos/weaviate/weaviate/releases?per_page=100',headers=auth_header)
+                response = requests.get('https://api.github.com/repos/weaviate/weaviate/releases?per_page=100')
                 if response.status_code == 200:
                     break
                 time.sleep(2**attempts)

--- a/.github/workflows/previous-version-test.yml
+++ b/.github/workflows/previous-version-test.yml
@@ -19,14 +19,13 @@ jobs:
         uses: ./.github/actions/get-previous-version
         id: test-patch
         with:
-          weaviate_version: '1.25.34'
+          weaviate_version: '1.25.25'
           jump_type: 'patch'
-          gh_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify patch output
         run: |
-          if [ "${{ steps.test-patch.outputs.previous_version }}" != "1.25.33" ]; then
-            echo "Expected version 1.25.33, got ${{ steps.test-patch.outputs.previous_version }}"
+          if [ "${{ steps.test-patch.outputs.previous_version }}" != "1.25.24" ]; then
+            echo "Expected version 1.25.24, got ${{ steps.test-patch.outputs.previous_version }}"
             exit 1
           fi
 
@@ -34,15 +33,14 @@ jobs:
         uses: ./.github/actions/get-previous-version
         id: test-patch-multiple
         with:
-          weaviate_version: '1.25.34'
+          weaviate_version: '1.25.25'
           jump_type: 'patch'
           jumps: '3'
-          gh_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify patch output
         run: |
-          if [ "${{ steps.test-patch-multiple.outputs.previous_version }}" != "1.25.31" ]; then
-            echo "Expected version 1.25.31, got ${{ steps.test-patch-multiple.outputs.previous_version }}"
+          if [ "${{ steps.test-patch-multiple.outputs.previous_version }}" != "1.25.22" ]; then
+            echo "Expected version 1.25.22, got ${{ steps.test-patch-multiple.outputs.previous_version }}"
             exit 1
           fi
 
@@ -53,7 +51,6 @@ jobs:
           weaviate_version: '1.26.13'
           jump_type: 'minor'
           jumps: '1'
-          gh_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify minor output
         run: |
@@ -69,7 +66,6 @@ jobs:
           weaviate_version: '1.27.10'
           jump_type: 'minor'
           jumps: '2'
-          gh_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify multiple jumps output
         run: |
@@ -85,7 +81,6 @@ jobs:
         with:
           weaviate_version: '0.0.0'
           jump_type: 'patch'
-          gh_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify invalid version fails
         run: |


### PR DESCRIPTION
Reverts weaviate/github-common-actions#9

It's causing some [failures in e2e tests](https://github.com/weaviate/weaviate-e2e-tests/actions/runs/16288212295/job/45991680587):
```
  File "/home/runner/work/_temp/84f53694-10a1-4288-b996-c15eb50214e3.py", line 51, in <module>
    prev_version = get_previous_version(current, 'minor', int('1'))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/_temp/84f53694-10a1-4288-b996-c15eb50214e3.py", line 31, in get_previous_version
    versions = get_versions()
               ^^^^^^^^^^^^^^
  File "/home/runner/work/_temp/84f53694-10a1-4288-b996-c15eb50214e3.py", line 14, in get_versions
    raise Exception(f"Failed to fetch releases: {response.status_code} Body: {response.json()}")
Exception: Failed to fetch releases: 401 Body: {'message': 'Bad credentials', 'documentation_url': 'https://docs.github.com/rest', 'status': '401'}
```