### PR TITLE
Add get-weaviate-branch and pull-weaviate-code actions

### DIFF
--- a/.github/actions/get-weaviate-branch/action.yml
+++ b/.github/actions/get-weaviate-branch/action.yml
@@ -1,0 +1,153 @@
+name: get-weaviate-branch
+description: 'Resolves a Weaviate Docker tag to the git ref (commit/branch) from weaviate/weaviate that matches the image code'
+inputs:
+  docker_tag:
+    description: 'The Docker tag to resolve (e.g. 1.36.6, preview-my-pr-abc1234.amd64, main-abc1234, nightly, latest)'
+    required: true
+  gh_token:
+    description: 'GitHub token for authenticated git operations and API calls (avoids rate limits)'
+    required: true
+outputs:
+  ref:
+    description: 'Best git ref for checkout (always a full 40-char commit hash)'
+    value: ${{ steps.resolve.outputs.ref }}
+  commit:
+    description: 'Full 40-char commit hash'
+    value: ${{ steps.resolve.outputs.commit }}
+  branch:
+    description: 'Branch name best-guess (empty if not determinable, e.g. for preview/PR tags)'
+    value: ${{ steps.resolve.outputs.branch }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Resolve Docker tag to git ref
+      id: resolve
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh_token }}
+      run: |
+        set -euo pipefail
+
+        # Authenticate git via HTTP header injected through env-based config.
+        # This avoids embedding the token in URLs (which leak in error messages/logs)
+        # and avoids writing to ~/.gitconfig (which persists beyond this step).
+        # These env vars are scoped to this shell step only.
+        AUTH_HEADER="Authorization: Basic $(echo -n "x-access-token:${GH_TOKEN}" | base64)"
+        export GIT_CONFIG_COUNT=1
+        export GIT_CONFIG_KEY_0="http.https://github.com/.extraHeader"
+        export GIT_CONFIG_VALUE_0="${AUTH_HEADER}"
+        export GIT_TERMINAL_PROMPT=0
+
+        WEAVIATE_REPO="https://github.com/weaviate/weaviate.git"
+        WEAVIATE_API="https://api.github.com/repos/weaviate/weaviate"
+        tag="${{ inputs.docker_tag }}"
+        commit=""
+        branch=""
+
+        echo "Resolving Docker tag: ${tag}"
+
+        # Step 1: Strip architecture suffix
+        tag_stripped="${tag}"
+        tag_stripped="${tag_stripped%.amd64}"
+        tag_stripped="${tag_stripped%.arm64}"
+
+        # Step 2: Handle special Docker-only tags
+        if [ "${tag_stripped}" = "nightly" ]; then
+          echo "Tag is 'nightly' — resolving main branch HEAD"
+          commit=$(git ls-remote "${WEAVIATE_REPO}" refs/heads/main | awk '{print $1}')
+          branch="main"
+        elif [ "${tag_stripped}" = "latest" ]; then
+          echo "Tag is 'latest' — finding highest release tag"
+          # Find the latest release tag name
+          latest_tag=$(git -c 'versionsort.suffix=-' ls-remote --tags --refs --sort='-v:refname' "${WEAVIATE_REPO}" \
+            | grep -oE 'refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | head -1 | sed 's|refs/tags/||')
+
+          # Resolve the annotated tag to its underlying commit (use ^{} dereferenced entry)
+          commit=$(git ls-remote --tags "${WEAVIATE_REPO}" "refs/tags/${latest_tag}" "refs/tags/${latest_tag}^{}" \
+            | tail -1 | awk '{print $1}')
+
+          # Extract major.minor for branch
+          version="${latest_tag#v}"
+          major_minor=$(echo "${version}" | grep -oE '^[0-9]+\.[0-9]+')
+          branch="stable/v${major_minor}"
+          echo "Resolved 'latest' to tag ${latest_tag} (commit ${commit})"
+        else
+          # Step 3: Try to extract 7-char hex hash from end (after last '-')
+          suffix="${tag_stripped##*-}"
+          if [[ "${suffix}" =~ ^[0-9a-f]{7}$ ]]; then
+            commit="${suffix}"
+            prefix="${tag_stripped%-*}"
+
+            # Step 4: Determine branch from prefix
+            if [[ "${prefix}" =~ ^preview- ]]; then
+              # Preview/PR build — branch is not recoverable from tag
+              branch=""
+              echo "Preview tag detected, short commit: ${commit}"
+            elif [[ "${prefix}" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+              # Semver prefix (e.g. 1.37.0-dev, 1.36.6) — branch not directly in tag
+              branch=""
+              echo "Semver+hash tag detected, short commit: ${commit}"
+            else
+              # Branch name prefix (e.g. main, stable-v1.34)
+              # In push_docker.sh, '/' in branch names is replaced with '-'
+              # Try common patterns to restore the original branch name
+              if [[ "${prefix}" =~ ^stable-v[0-9]+\.[0-9]+$ ]]; then
+                branch="${prefix/stable-/stable/}"
+              else
+                # For simple branch names (main, feature-x), keep as-is
+                # Cannot reliably restore '/' for arbitrary branches
+                branch="${prefix}"
+              fi
+              echo "Branch tag detected, branch: ${branch}, short commit: ${commit}"
+            fi
+          else
+            # Step 5: No hash found — must be a release version tag (X.Y.Z or X.Y.Z-rc.N)
+            version="${tag_stripped}"
+            git_tag="v${version}"
+            echo "Release tag detected: ${git_tag} — resolving commit from git"
+
+            # Resolve the annotated tag to its commit (use ^{} dereferenced entry if present)
+            tag_commit=$(git ls-remote --tags "${WEAVIATE_REPO}" "refs/tags/${git_tag}" "refs/tags/${git_tag}^{}" \
+              | tail -1 | awk '{print $1}')
+
+            if [ -z "${tag_commit}" ]; then
+              echo "::error::Could not find git tag ${git_tag} in weaviate/weaviate"
+              exit 1
+            fi
+
+            commit="${tag_commit}"
+            # Extract major.minor for stable branch
+            major_minor=$(echo "${version}" | grep -oE '^[0-9]+\.[0-9]+')
+            branch="stable/v${major_minor}"
+            echo "Resolved ${git_tag} to commit ${commit}"
+          fi
+        fi
+
+        # Step 6: Resolve short hashes (7-char) to full 40-char SHA via GitHub API
+        if [ "${#commit}" -lt 40 ]; then
+          echo "Resolving short hash ${commit} to full SHA..."
+          full_sha=$(curl -sf \
+            -H "Authorization: token ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "${WEAVIATE_API}/commits/${commit}" \
+            | grep -m1 '"sha"' | grep -oE '[0-9a-f]{40}')
+
+          if [ -z "${full_sha}" ]; then
+            echo "::error::Could not resolve short hash ${commit} to a full SHA"
+            exit 1
+          fi
+          echo "Resolved ${commit} -> ${full_sha}"
+          commit="${full_sha}"
+        fi
+
+        ref="${commit}"
+
+        echo "ref=${ref}" >> "${GITHUB_OUTPUT}"
+        echo "commit=${commit}" >> "${GITHUB_OUTPUT}"
+        echo "branch=${branch}" >> "${GITHUB_OUTPUT}"
+
+        echo "--- Results ---"
+        echo "ref:    ${ref}"
+        echo "commit: ${commit}"
+        echo "branch: ${branch}"

--- a/.github/actions/get-weaviate-branch/action.yml
+++ b/.github/actions/get-weaviate-branch/action.yml
@@ -5,8 +5,9 @@ inputs:
     description: 'The Docker tag to resolve (e.g. 1.36.6, preview-my-pr-abc1234.amd64, main-abc1234, nightly, latest)'
     required: true
   gh_token:
-    description: 'GitHub token for authenticated git operations and API calls (avoids rate limits)'
-    required: true
+    description: 'GitHub token for API calls to resolve short commit hashes (avoids rate limits). Optional but recommended.'
+    required: false
+    default: ''
 outputs:
   ref:
     description: 'Best git ref for checkout (always a full 40-char commit hash)'
@@ -28,16 +29,9 @@ runs:
       run: |
         set -euo pipefail
 
-        # Authenticate git via HTTP header injected through env-based config.
-        # This avoids embedding the token in URLs (which leak in error messages/logs)
-        # and avoids writing to ~/.gitconfig (which persists beyond this step).
-        # These env vars are scoped to this shell step only.
-        AUTH_HEADER="Authorization: Basic $(echo -n "x-access-token:${GH_TOKEN}" | base64)"
-        export GIT_CONFIG_COUNT=1
-        export GIT_CONFIG_KEY_0="http.https://github.com/.extraHeader"
-        export GIT_CONFIG_VALUE_0="${AUTH_HEADER}"
-        export GIT_TERMINAL_PROMPT=0
-
+        # weaviate/weaviate is a public repo — git operations (ls-remote, fetch)
+        # work without authentication. The token is only needed for the GitHub
+        # API call that resolves short commit hashes (step 6).
         WEAVIATE_REPO="https://github.com/weaviate/weaviate.git"
         WEAVIATE_API="https://api.github.com/repos/weaviate/weaviate"
         tag="${{ inputs.docker_tag }}"
@@ -58,10 +52,11 @@ runs:
           branch="main"
         elif [ "${tag_stripped}" = "latest" ]; then
           echo "Tag is 'latest' — finding highest release tag"
-          # Find the latest release tag name
-          latest_tag=$(git -c 'versionsort.suffix=-' ls-remote --tags --refs --sort='-v:refname' "${WEAVIATE_REPO}" \
-            | grep -oE 'refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$' \
-            | head -1 | sed 's|refs/tags/||')
+          # Find the latest release tag name — capture full output to avoid
+          # broken pipe from head -1 under pipefail.
+          all_tags=$(git -c 'versionsort.suffix=-' ls-remote --tags --refs --sort='-v:refname' "${WEAVIATE_REPO}" \
+            | grep -oE 'refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$' || true)
+          latest_tag=$(echo "${all_tags}" | head -1 | sed 's|refs/tags/||')
 
           # Resolve the annotated tag to its underlying commit (use ^{} dereferenced entry)
           commit=$(git ls-remote --tags "${WEAVIATE_REPO}" "refs/tags/${latest_tag}" "refs/tags/${latest_tag}^{}" \
@@ -69,7 +64,7 @@ runs:
 
           # Extract major.minor for branch
           version="${latest_tag#v}"
-          major_minor=$(echo "${version}" | grep -oE '^[0-9]+\.[0-9]+')
+          major_minor="${version%.*}"
           branch="stable/v${major_minor}"
           echo "Resolved 'latest' to tag ${latest_tag} (commit ${commit})"
         else
@@ -118,7 +113,7 @@ runs:
 
             commit="${tag_commit}"
             # Extract major.minor for stable branch
-            major_minor=$(echo "${version}" | grep -oE '^[0-9]+\.[0-9]+')
+            major_minor="${version%.*}"
             branch="stable/v${major_minor}"
             echo "Resolved ${git_tag} to commit ${commit}"
           fi
@@ -127,11 +122,17 @@ runs:
         # Step 6: Resolve short hashes (7-char) to full 40-char SHA via GitHub API
         if [ "${#commit}" -lt 40 ]; then
           echo "Resolving short hash ${commit} to full SHA..."
-          full_sha=$(curl -sf \
-            -H "Authorization: token ${GH_TOKEN}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            "${WEAVIATE_API}/commits/${commit}" \
-            | grep -m1 '"sha"' | grep -oE '[0-9a-f]{40}')
+          # Capture full response first to avoid broken-pipe (exit 23) from
+          # curl when piped to grep -m1 under pipefail.
+          curl_args=(-sf -H "Accept: application/vnd.github.v3+json")
+          if [ -n "${GH_TOKEN}" ]; then
+            curl_args+=(-H "Authorization: token ${GH_TOKEN}")
+          fi
+          response=$(curl "${curl_args[@]}" "${WEAVIATE_API}/commits/${commit}")
+          # Extract SHA without grep -m1 pipe to avoid broken pipe under pipefail.
+          # The first "sha" in the response is the commit SHA.
+          all_shas=$(echo "${response}" | sed -n 's/.*"sha": *"\([0-9a-f]\{40\}\)".*/\1/p')
+          full_sha=$(echo "${all_shas}" | head -1)
 
           if [ -z "${full_sha}" ]; then
             echo "::error::Could not resolve short hash ${commit} to a full SHA"

--- a/.github/actions/get-weaviate-branch/action.yml
+++ b/.github/actions/get-weaviate-branch/action.yml
@@ -57,14 +57,22 @@ runs:
           all_tags=$(git -c 'versionsort.suffix=-' ls-remote --tags --refs --sort='-v:refname' "${WEAVIATE_REPO}" \
             | grep -oE 'refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$' || true)
           latest_tag=$(echo "${all_tags}" | head -1 | sed 's|refs/tags/||')
+          if [ -z "${latest_tag}" ]; then
+            echo "::error::Failed to find any release tag for 'latest' Docker tag"
+            exit 1
+          fi
 
           # Resolve the annotated tag to its underlying commit (use ^{} dereferenced entry)
           commit=$(git ls-remote --tags "${WEAVIATE_REPO}" "refs/tags/${latest_tag}" "refs/tags/${latest_tag}^{}" \
             | tail -1 | awk '{print $1}')
+          if [ -z "${commit}" ]; then
+            echo "::error::Failed to resolve commit for tag '${latest_tag}'"
+            exit 1
+          fi
 
           # Extract major.minor for branch
           version="${latest_tag#v}"
-          major_minor="${version%.*}"
+          major_minor=$(echo "${version}" | grep -oE '^[0-9]+\.[0-9]+')
           branch="stable/v${major_minor}"
           echo "Resolved 'latest' to tag ${latest_tag} (commit ${commit})"
         else
@@ -112,23 +120,28 @@ runs:
             fi
 
             commit="${tag_commit}"
-            # Extract major.minor for stable branch
-            major_minor="${version%.*}"
+            # Extract major.minor for stable branch (grep handles RC versions like 1.36.0-rc.0 → 1.36)
+            major_minor=$(echo "${version}" | grep -oE '^[0-9]+\.[0-9]+')
             branch="stable/v${major_minor}"
             echo "Resolved ${git_tag} to commit ${commit}"
           fi
         fi
 
         # Step 6: Resolve short hashes (7-char) to full 40-char SHA via GitHub API
+        if [ -z "${commit}" ]; then
+          echo "::error::No commit hash could be extracted from Docker tag '${tag}'"
+          exit 1
+        fi
         if [ "${#commit}" -lt 40 ]; then
           echo "Resolving short hash ${commit} to full SHA..."
-          # Capture full response first to avoid broken-pipe (exit 23) from
-          # curl when piped to grep -m1 under pipefail.
           curl_args=(-sf -H "Accept: application/vnd.github.v3+json")
           if [ -n "${GH_TOKEN}" ]; then
-            curl_args+=(-H "Authorization: token ${GH_TOKEN}")
+            curl_args+=(-H "Authorization: Bearer ${GH_TOKEN}")
           fi
-          response=$(curl "${curl_args[@]}" "${WEAVIATE_API}/commits/${commit}")
+          if ! response=$(curl "${curl_args[@]}" "${WEAVIATE_API}/commits/${commit}"); then
+            echo "::error::GitHub API call failed when resolving short hash '${commit}'"
+            exit 1
+          fi
           # Extract SHA without grep -m1 pipe to avoid broken pipe under pipefail.
           # The first "sha" in the response is the commit SHA.
           all_shas=$(echo "${response}" | sed -n 's/.*"sha": *"\([0-9a-f]\{40\}\)".*/\1/p')

--- a/.github/actions/get-weaviate-branch/action.yml
+++ b/.github/actions/get-weaviate-branch/action.yml
@@ -142,10 +142,7 @@ runs:
             echo "::error::GitHub API call failed when resolving short hash '${commit}'"
             exit 1
           fi
-          # Extract SHA without grep -m1 pipe to avoid broken pipe under pipefail.
-          # The first "sha" in the response is the commit SHA.
-          all_shas=$(echo "${response}" | sed -n 's/.*"sha": *"\([0-9a-f]\{40\}\)".*/\1/p')
-          full_sha=$(echo "${all_shas}" | head -1)
+          full_sha=$(printf '%s\n' "${response}" | jq -r '.sha // empty')
 
           if [ -z "${full_sha}" ]; then
             echo "::error::Could not resolve short hash ${commit} to a full SHA"

--- a/.github/actions/pull-weaviate-code/action.yml
+++ b/.github/actions/pull-weaviate-code/action.yml
@@ -9,8 +9,9 @@ inputs:
     required: false
     default: '.'
   gh_token:
-    description: 'GitHub token for authenticated API requests and git operations (avoids rate limits)'
-    required: true
+    description: 'GitHub token passed to get-weaviate-branch for API calls (avoids rate limits). Optional but recommended.'
+    required: false
+    default: ''
 outputs:
   ref:
     description: 'The git ref that was checked out (full 40-char commit hash)'
@@ -37,27 +38,18 @@ runs:
     - name: Clone weaviate at resolved ref
       id: clone
       shell: bash
-      env:
-        GH_TOKEN: ${{ inputs.gh_token }}
       run: |
         set -euo pipefail
 
-        # Authenticate git via HTTP header injected through env-based config.
-        # These env vars are scoped to this shell step — no cleanup needed.
-        AUTH_HEADER="Authorization: Basic $(echo -n "x-access-token:${GH_TOKEN}" | base64)"
-        export GIT_CONFIG_COUNT=1
-        export GIT_CONFIG_KEY_0="http.https://github.com/.extraHeader"
-        export GIT_CONFIG_VALUE_0="${AUTH_HEADER}"
-        export GIT_TERMINAL_PROMPT=0
-
+        # weaviate/weaviate is a public repo — no auth needed for git fetch.
         WEAVIATE_REPO="https://github.com/weaviate/weaviate.git"
         TARGET_DIR="${{ inputs.directory }}"
         WEAVIATE_DIR="${TARGET_DIR}/weaviate"
         COMMIT="${{ steps.resolve-tag.outputs.commit }}"
 
-        # Check that the weaviate folder doesn't already exist
-        if [ -d "${WEAVIATE_DIR}" ]; then
-          echo "::error::Directory '${WEAVIATE_DIR}' already exists. Remove it before running this action to avoid conflicts."
+        # Check that the weaviate path doesn't already exist (file, directory, or symlink)
+        if [ -e "${WEAVIATE_DIR}" ]; then
+          echo "::error::Path '${WEAVIATE_DIR}' already exists. Remove it before running this action to avoid conflicts."
           exit 1
         fi
 

--- a/.github/actions/pull-weaviate-code/action.yml
+++ b/.github/actions/pull-weaviate-code/action.yml
@@ -1,0 +1,76 @@
+name: pull-weaviate-code
+description: 'Clones the weaviate/weaviate repository at the commit matching a given Docker tag'
+inputs:
+  docker_tag:
+    description: 'Weaviate Docker tag to resolve (e.g. 1.36.6, preview-my-pr-abc1234.amd64, main-abc1234, nightly, latest)'
+    required: true
+  directory:
+    description: 'Directory in which to clone the weaviate repository (a "weaviate" folder will be created inside it)'
+    required: false
+    default: '.'
+  gh_token:
+    description: 'GitHub token for authenticated API requests and git operations (avoids rate limits)'
+    required: true
+outputs:
+  ref:
+    description: 'The git ref that was checked out (full 40-char commit hash)'
+    value: ${{ steps.resolve-tag.outputs.ref }}
+  commit:
+    description: 'Full 40-char commit hash that was checked out'
+    value: ${{ steps.resolve-tag.outputs.commit }}
+  branch:
+    description: 'The branch name (if determinable)'
+    value: ${{ steps.resolve-tag.outputs.branch }}
+  weaviate_path:
+    description: 'Full path to the cloned weaviate directory'
+    value: ${{ steps.clone.outputs.weaviate_path }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Resolve Docker tag to git ref
+      id: resolve-tag
+      uses: ./.github/actions/get-weaviate-branch
+      with:
+        docker_tag: ${{ inputs.docker_tag }}
+        gh_token: ${{ inputs.gh_token }}
+
+    - name: Clone weaviate at resolved ref
+      id: clone
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh_token }}
+      run: |
+        set -euo pipefail
+
+        # Authenticate git via HTTP header injected through env-based config.
+        # These env vars are scoped to this shell step — no cleanup needed.
+        AUTH_HEADER="Authorization: Basic $(echo -n "x-access-token:${GH_TOKEN}" | base64)"
+        export GIT_CONFIG_COUNT=1
+        export GIT_CONFIG_KEY_0="http.https://github.com/.extraHeader"
+        export GIT_CONFIG_VALUE_0="${AUTH_HEADER}"
+        export GIT_TERMINAL_PROMPT=0
+
+        WEAVIATE_REPO="https://github.com/weaviate/weaviate.git"
+        TARGET_DIR="${{ inputs.directory }}"
+        WEAVIATE_DIR="${TARGET_DIR}/weaviate"
+        COMMIT="${{ steps.resolve-tag.outputs.commit }}"
+
+        # Check that the weaviate folder doesn't already exist
+        if [ -d "${WEAVIATE_DIR}" ]; then
+          echo "::error::Directory '${WEAVIATE_DIR}' already exists. Remove it before running this action to avoid conflicts."
+          exit 1
+        fi
+
+        # Ensure parent directory exists
+        mkdir -p "${TARGET_DIR}"
+
+        echo "Cloning weaviate at commit ${COMMIT} into ${WEAVIATE_DIR}..."
+        git init "${WEAVIATE_DIR}"
+        cd "${WEAVIATE_DIR}"
+        git remote add origin "${WEAVIATE_REPO}"
+        git fetch --depth=1 origin "${COMMIT}"
+        git checkout FETCH_HEAD
+
+        FULL_PATH="$(pwd)"
+        echo "weaviate_path=${FULL_PATH}" >> "${GITHUB_OUTPUT}"
+        echo "Successfully cloned weaviate at ${COMMIT} to ${FULL_PATH}"

--- a/.github/workflows/get-weaviate-branch-test.yml
+++ b/.github/workflows/get-weaviate-branch-test.yml
@@ -1,0 +1,360 @@
+name: Test Get Weaviate Branch Action
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - '.github/actions/get-weaviate-branch/**'
+      - '.github/workflows/get-weaviate-branch-test.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  semver-hash-arch:
+    name: "Tag: semver + hash + arch (1.36.6-76e62e8.amd64)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Resolve tag
+        id: resolve
+        uses: ./.github/actions/get-weaviate-branch
+        with:
+          docker_tag: "1.36.6-76e62e8.amd64"
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify outputs
+        run: |
+          COMMIT="${{ steps.resolve.outputs.commit }}"
+          # Should be a full 40-char hash resolved from short hash 76e62e8
+          if ! [[ "${COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Expected 40-char commit hash, got=${COMMIT}"
+            exit 1
+          fi
+          # Must contain the original short hash
+          if [[ "${COMMIT}" != *"76e62e8"* ]]; then
+            echo "Expected commit to contain 76e62e8, got=${COMMIT}"
+            exit 1
+          fi
+          # Ref should equal commit
+          if [ "${{ steps.resolve.outputs.ref }}" != "${COMMIT}" ]; then
+            echo "Expected ref to equal commit"
+            exit 1
+          fi
+          # Branch should be empty for semver+hash tags
+          if [ -n "${{ steps.resolve.outputs.branch }}" ]; then
+            echo "Expected empty branch, got=${{ steps.resolve.outputs.branch }}"
+            exit 1
+          fi
+
+  semver-hash-no-arch:
+    name: "Tag: semver + hash no arch (1.36.6-76e62e8)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Resolve tag
+        id: resolve
+        uses: ./.github/actions/get-weaviate-branch
+        with:
+          docker_tag: "1.36.6-76e62e8"
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify outputs
+        run: |
+          COMMIT="${{ steps.resolve.outputs.commit }}"
+          if ! [[ "${COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Expected 40-char commit hash, got=${COMMIT}"
+            exit 1
+          fi
+          if [[ "${COMMIT}" != *"76e62e8"* ]]; then
+            echo "Expected commit to contain 76e62e8, got=${COMMIT}"
+            exit 1
+          fi
+
+  semver-dev-hash:
+    name: "Tag: semver-dev + hash (1.37.0-dev-01c9f49)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Resolve tag
+        id: resolve
+        uses: ./.github/actions/get-weaviate-branch
+        with:
+          docker_tag: "1.37.0-dev-01c9f49"
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify outputs
+        run: |
+          COMMIT="${{ steps.resolve.outputs.commit }}"
+          if ! [[ "${COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Expected 40-char commit hash, got=${COMMIT}"
+            exit 1
+          fi
+          if [[ "${COMMIT}" != *"01c9f49"* ]]; then
+            echo "Expected commit to contain 01c9f49, got=${COMMIT}"
+            exit 1
+          fi
+
+  preview-tag:
+    name: "Tag: preview + hash + arch"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Resolve tag
+        id: resolve
+        uses: ./.github/actions/get-weaviate-branch
+        with:
+          docker_tag: "preview-do-not-merge-test-only-perf-compaction-replace-76e62e8.amd64"
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify outputs
+        run: |
+          COMMIT="${{ steps.resolve.outputs.commit }}"
+          if ! [[ "${COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Expected 40-char commit hash, got=${COMMIT}"
+            exit 1
+          fi
+          if [[ "${COMMIT}" != *"76e62e8"* ]]; then
+            echo "Expected commit to contain 76e62e8, got=${COMMIT}"
+            exit 1
+          fi
+          # Branch should be empty for preview tags
+          if [ -n "${{ steps.resolve.outputs.branch }}" ]; then
+            echo "Expected empty branch, got=${{ steps.resolve.outputs.branch }}"
+            exit 1
+          fi
+
+  branch-main-tag:
+    name: "Tag: main branch + hash (main-01c9f49)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Resolve tag
+        id: resolve
+        uses: ./.github/actions/get-weaviate-branch
+        with:
+          docker_tag: "main-01c9f49"
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify outputs
+        run: |
+          COMMIT="${{ steps.resolve.outputs.commit }}"
+          if ! [[ "${COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Expected 40-char commit hash, got=${COMMIT}"
+            exit 1
+          fi
+          if [[ "${COMMIT}" != *"01c9f49"* ]]; then
+            echo "Expected commit to contain 01c9f49, got=${COMMIT}"
+            exit 1
+          fi
+          if [ "${{ steps.resolve.outputs.branch }}" != "main" ]; then
+            echo "Expected branch=main, got=${{ steps.resolve.outputs.branch }}"
+            exit 1
+          fi
+
+  stable-branch-tag:
+    name: "Tag: stable branch + hash (stable-v1.34-92f8f63)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Resolve tag
+        id: resolve
+        uses: ./.github/actions/get-weaviate-branch
+        with:
+          docker_tag: "stable-v1.34-92f8f63"
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify outputs
+        run: |
+          COMMIT="${{ steps.resolve.outputs.commit }}"
+          if ! [[ "${COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Expected 40-char commit hash, got=${COMMIT}"
+            exit 1
+          fi
+          if [[ "${COMMIT}" != *"92f8f63"* ]]; then
+            echo "Expected commit to contain 92f8f63, got=${COMMIT}"
+            exit 1
+          fi
+          if [ "${{ steps.resolve.outputs.branch }}" != "stable/v1.34" ]; then
+            echo "Expected branch=stable/v1.34, got=${{ steps.resolve.outputs.branch }}"
+            exit 1
+          fi
+
+  release-tag:
+    name: "Tag: official release (1.36.6)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Resolve tag
+        id: resolve
+        uses: ./.github/actions/get-weaviate-branch
+        with:
+          docker_tag: "1.36.6"
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify outputs
+        run: |
+          COMMIT="${{ steps.resolve.outputs.commit }}"
+          BRANCH="${{ steps.resolve.outputs.branch }}"
+          REF="${{ steps.resolve.outputs.ref }}"
+
+          # Commit should be a full 40-char hex hash
+          if ! [[ "${COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Expected 40-char commit hash, got=${COMMIT}"
+            exit 1
+          fi
+
+          # Ref should equal the resolved commit
+          if [ "${REF}" != "${COMMIT}" ]; then
+            echo "Expected ref to equal commit, ref=${REF}, commit=${COMMIT}"
+            exit 1
+          fi
+
+          # Branch should be stable/v1.36
+          if [ "${BRANCH}" != "stable/v1.36" ]; then
+            echo "Expected branch=stable/v1.36, got=${BRANCH}"
+            exit 1
+          fi
+
+  release-rc-tag:
+    name: "Tag: release candidate (1.36.0-rc.0)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Resolve tag
+        id: resolve
+        uses: ./.github/actions/get-weaviate-branch
+        with:
+          docker_tag: "1.36.0-rc.0"
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify outputs
+        run: |
+          COMMIT="${{ steps.resolve.outputs.commit }}"
+          BRANCH="${{ steps.resolve.outputs.branch }}"
+
+          # Commit should be a full 40-char hex hash
+          if ! [[ "${COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Expected 40-char commit hash, got=${COMMIT}"
+            exit 1
+          fi
+
+          if [ "${BRANCH}" != "stable/v1.36" ]; then
+            echo "Expected branch=stable/v1.36, got=${BRANCH}"
+            exit 1
+          fi
+
+  nightly-tag:
+    name: "Tag: nightly"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Resolve tag
+        id: resolve
+        uses: ./.github/actions/get-weaviate-branch
+        with:
+          docker_tag: "nightly"
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify outputs
+        run: |
+          COMMIT="${{ steps.resolve.outputs.commit }}"
+          BRANCH="${{ steps.resolve.outputs.branch }}"
+
+          # Commit should be a full 40-char hex hash
+          if ! [[ "${COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Expected 40-char commit hash, got=${COMMIT}"
+            exit 1
+          fi
+
+          if [ "${BRANCH}" != "main" ]; then
+            echo "Expected branch=main, got=${BRANCH}"
+            exit 1
+          fi
+
+  latest-tag:
+    name: "Tag: latest"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Resolve tag
+        id: resolve
+        uses: ./.github/actions/get-weaviate-branch
+        with:
+          docker_tag: "latest"
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify outputs
+        run: |
+          COMMIT="${{ steps.resolve.outputs.commit }}"
+          BRANCH="${{ steps.resolve.outputs.branch }}"
+          REF="${{ steps.resolve.outputs.ref }}"
+
+          # Commit should be a full 40-char hex hash
+          if ! [[ "${COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Expected 40-char commit hash, got=${COMMIT}"
+            exit 1
+          fi
+
+          # Ref should equal the resolved commit
+          if [ "${REF}" != "${COMMIT}" ]; then
+            echo "Expected ref to equal commit, ref=${REF}, commit=${COMMIT}"
+            exit 1
+          fi
+
+          # Branch should be stable/vX.Y
+          if ! [[ "${BRANCH}" =~ ^stable/v[0-9]+\.[0-9]+$ ]]; then
+            echo "Expected branch matching stable/vX.Y, got=${BRANCH}"
+            exit 1
+          fi
+
+  arm64-suffix:
+    name: "Tag: arm64 suffix stripped (main-01c9f49.arm64)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Resolve tag
+        id: resolve
+        uses: ./.github/actions/get-weaviate-branch
+        with:
+          docker_tag: "main-01c9f49.arm64"
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify outputs
+        run: |
+          COMMIT="${{ steps.resolve.outputs.commit }}"
+          if ! [[ "${COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Expected 40-char commit hash, got=${COMMIT}"
+            exit 1
+          fi
+          if [[ "${COMMIT}" != *"01c9f49"* ]]; then
+            echo "Expected commit to contain 01c9f49, got=${COMMIT}"
+            exit 1
+          fi
+          if [ "${{ steps.resolve.outputs.branch }}" != "main" ]; then
+            echo "Expected branch=main, got=${{ steps.resolve.outputs.branch }}"
+            exit 1
+          fi

--- a/.github/workflows/get-weaviate-branch-test.yml
+++ b/.github/workflows/get-weaviate-branch-test.yml
@@ -12,31 +12,31 @@ permissions:
   contents: read
 
 jobs:
+  # Real Docker tag: semitechnologies/weaviate:1.34.19-6175eab.amd64
   semver-hash-arch:
-    name: "Tag: semver + hash + arch (1.36.6-76e62e8.amd64)"
+    name: "Tag: semver + hash + arch (1.34.19-6175eab.amd64)"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Resolve tag
         id: resolve
         uses: ./.github/actions/get-weaviate-branch
         with:
-          docker_tag: "1.36.6-76e62e8.amd64"
+          docker_tag: "1.34.19-6175eab.amd64"
           gh_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify outputs
         run: |
           COMMIT="${{ steps.resolve.outputs.commit }}"
-          # Should be a full 40-char hash resolved from short hash 76e62e8
+          # Should be a full 40-char hash resolved from short hash 6175eab
           if ! [[ "${COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
             echo "Expected 40-char commit hash, got=${COMMIT}"
             exit 1
           fi
-          # Must contain the original short hash
-          if [[ "${COMMIT}" != *"76e62e8"* ]]; then
-            echo "Expected commit to contain 76e62e8, got=${COMMIT}"
+          if [[ "${COMMIT}" != *"6175eab"* ]]; then
+            echo "Expected commit to contain 6175eab, got=${COMMIT}"
             exit 1
           fi
           # Ref should equal commit
@@ -50,18 +50,19 @@ jobs:
             exit 1
           fi
 
+  # Real Docker tag: semitechnologies/weaviate:1.37.0-dev-305c7dc.amd64
   semver-hash-no-arch:
-    name: "Tag: semver + hash no arch (1.36.6-76e62e8)"
+    name: "Tag: semver + hash no arch (1.37.0-dev-305c7dc)"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Resolve tag
         id: resolve
         uses: ./.github/actions/get-weaviate-branch
         with:
-          docker_tag: "1.36.6-76e62e8"
+          docker_tag: "1.37.0-dev-305c7dc"
           gh_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify outputs
@@ -71,23 +72,24 @@ jobs:
             echo "Expected 40-char commit hash, got=${COMMIT}"
             exit 1
           fi
-          if [[ "${COMMIT}" != *"76e62e8"* ]]; then
-            echo "Expected commit to contain 76e62e8, got=${COMMIT}"
+          if [[ "${COMMIT}" != *"305c7dc"* ]]; then
+            echo "Expected commit to contain 305c7dc, got=${COMMIT}"
             exit 1
           fi
 
+  # Real Docker tag: semitechnologies/weaviate:1.37.0-dev-305c7dc.amd64
   semver-dev-hash:
-    name: "Tag: semver-dev + hash (1.37.0-dev-01c9f49)"
+    name: "Tag: semver-dev + hash + arch (1.37.0-dev-305c7dc.amd64)"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Resolve tag
         id: resolve
         uses: ./.github/actions/get-weaviate-branch
         with:
-          docker_tag: "1.37.0-dev-01c9f49"
+          docker_tag: "1.37.0-dev-305c7dc.amd64"
           gh_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify outputs
@@ -97,23 +99,24 @@ jobs:
             echo "Expected 40-char commit hash, got=${COMMIT}"
             exit 1
           fi
-          if [[ "${COMMIT}" != *"01c9f49"* ]]; then
-            echo "Expected commit to contain 01c9f49, got=${COMMIT}"
+          if [[ "${COMMIT}" != *"305c7dc"* ]]; then
+            echo "Expected commit to contain 305c7dc, got=${COMMIT}"
             exit 1
           fi
 
+  # Real Docker tag: semitechnologies/weaviate:preview-perf-compaction-replace-use-less-heap-6175eab.amd64
   preview-tag:
     name: "Tag: preview + hash + arch"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Resolve tag
         id: resolve
         uses: ./.github/actions/get-weaviate-branch
         with:
-          docker_tag: "preview-do-not-merge-test-only-perf-compaction-replace-76e62e8.amd64"
+          docker_tag: "preview-perf-compaction-replace-use-less-heap-6175eab.amd64"
           gh_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify outputs
@@ -123,8 +126,8 @@ jobs:
             echo "Expected 40-char commit hash, got=${COMMIT}"
             exit 1
           fi
-          if [[ "${COMMIT}" != *"76e62e8"* ]]; then
-            echo "Expected commit to contain 76e62e8, got=${COMMIT}"
+          if [[ "${COMMIT}" != *"6175eab"* ]]; then
+            echo "Expected commit to contain 6175eab, got=${COMMIT}"
             exit 1
           fi
           # Branch should be empty for preview tags
@@ -133,12 +136,13 @@ jobs:
             exit 1
           fi
 
+  # Real Docker tag: semitechnologies/weaviate:main-01c9f49
   branch-main-tag:
     name: "Tag: main branch + hash (main-01c9f49)"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Resolve tag
         id: resolve
@@ -163,18 +167,19 @@ jobs:
             exit 1
           fi
 
+  # Real Docker tag: semitechnologies/weaviate:stable-v1.34-519f0dc
   stable-branch-tag:
-    name: "Tag: stable branch + hash (stable-v1.34-92f8f63)"
+    name: "Tag: stable branch + hash (stable-v1.34-519f0dc)"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Resolve tag
         id: resolve
         uses: ./.github/actions/get-weaviate-branch
         with:
-          docker_tag: "stable-v1.34-92f8f63"
+          docker_tag: "stable-v1.34-519f0dc"
           gh_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify outputs
@@ -184,8 +189,8 @@ jobs:
             echo "Expected 40-char commit hash, got=${COMMIT}"
             exit 1
           fi
-          if [[ "${COMMIT}" != *"92f8f63"* ]]; then
-            echo "Expected commit to contain 92f8f63, got=${COMMIT}"
+          if [[ "${COMMIT}" != *"519f0dc"* ]]; then
+            echo "Expected commit to contain 519f0dc, got=${COMMIT}"
             exit 1
           fi
           if [ "${{ steps.resolve.outputs.branch }}" != "stable/v1.34" ]; then
@@ -198,7 +203,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Resolve tag
         id: resolve
@@ -236,7 +241,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Resolve tag
         id: resolve
@@ -256,8 +261,8 @@ jobs:
             exit 1
           fi
 
-          if [ "${BRANCH}" != "stable/v1.36" ]; then
-            echo "Expected branch=stable/v1.36, got=${BRANCH}"
+          if [ "${BRANCH}" != "stable/v1.36.0-rc" ]; then
+            echo "Expected branch=stable/v1.36.0-rc, got=${BRANCH}"
             exit 1
           fi
 
@@ -266,7 +271,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Resolve tag
         id: resolve
@@ -296,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Resolve tag
         id: resolve
@@ -329,18 +334,19 @@ jobs:
             exit 1
           fi
 
+  # Real Docker tag: semitechnologies/weaviate:1.34.19-6175eab.arm64
   arm64-suffix:
-    name: "Tag: arm64 suffix stripped (main-01c9f49.arm64)"
+    name: "Tag: arm64 suffix stripped (1.34.19-6175eab.arm64)"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Resolve tag
         id: resolve
         uses: ./.github/actions/get-weaviate-branch
         with:
-          docker_tag: "main-01c9f49.arm64"
+          docker_tag: "1.34.19-6175eab.arm64"
           gh_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify outputs
@@ -350,11 +356,7 @@ jobs:
             echo "Expected 40-char commit hash, got=${COMMIT}"
             exit 1
           fi
-          if [[ "${COMMIT}" != *"01c9f49"* ]]; then
-            echo "Expected commit to contain 01c9f49, got=${COMMIT}"
-            exit 1
-          fi
-          if [ "${{ steps.resolve.outputs.branch }}" != "main" ]; then
-            echo "Expected branch=main, got=${{ steps.resolve.outputs.branch }}"
+          if [[ "${COMMIT}" != *"6175eab"* ]]; then
+            echo "Expected commit to contain 6175eab, got=${COMMIT}"
             exit 1
           fi

--- a/.github/workflows/get-weaviate-branch-test.yml
+++ b/.github/workflows/get-weaviate-branch-test.yml
@@ -261,8 +261,8 @@ jobs:
             exit 1
           fi
 
-          if [ "${BRANCH}" != "stable/v1.36.0-rc" ]; then
-            echo "Expected branch=stable/v1.36.0-rc, got=${BRANCH}"
+          if [ "${BRANCH}" != "stable/v1.36" ]; then
+            echo "Expected branch=stable/v1.36, got=${BRANCH}"
             exit 1
           fi
 

--- a/.github/workflows/pull-weaviate-code-test.yml
+++ b/.github/workflows/pull-weaviate-code-test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Pull weaviate code
         id: pull
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Pull weaviate code
         id: pull
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Pull weaviate code into custom dir
         id: pull
@@ -129,7 +129,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Create conflicting directory
         run: mkdir -p ./weaviate
@@ -155,7 +155,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Pull weaviate code
         id: pull

--- a/.github/workflows/pull-weaviate-code-test.yml
+++ b/.github/workflows/pull-weaviate-code-test.yml
@@ -1,0 +1,184 @@
+name: Test Pull Weaviate Code Action
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - '.github/actions/pull-weaviate-code/**'
+      - '.github/actions/get-weaviate-branch/**'
+      - '.github/workflows/pull-weaviate-code-test.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  release-tag:
+    name: "Clone from release tag (1.36.6)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Pull weaviate code
+        id: pull
+        uses: ./.github/actions/pull-weaviate-code
+        with:
+          docker_tag: "1.36.6"
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify clone
+        run: |
+          # Directory should exist
+          if [ ! -d "${{ steps.pull.outputs.weaviate_path }}" ]; then
+            echo "Weaviate directory not found at ${{ steps.pull.outputs.weaviate_path }}"
+            exit 1
+          fi
+
+          # Should contain weaviate source files
+          if [ ! -f "${{ steps.pull.outputs.weaviate_path }}/go.mod" ]; then
+            echo "go.mod not found — clone appears incomplete"
+            exit 1
+          fi
+
+          # Commit should be a 40-char hash
+          COMMIT="${{ steps.pull.outputs.commit }}"
+          if ! [[ "${COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Expected 40-char commit hash, got=${COMMIT}"
+            exit 1
+          fi
+
+          # Verify HEAD matches the resolved commit
+          cd "${{ steps.pull.outputs.weaviate_path }}"
+          HEAD_SHA=$(git rev-parse HEAD)
+          if [ "${HEAD_SHA}" != "${COMMIT}" ]; then
+            echo "HEAD (${HEAD_SHA}) does not match expected commit (${COMMIT})"
+            exit 1
+          fi
+
+          echo "Branch: ${{ steps.pull.outputs.branch }}"
+          echo "Commit: ${COMMIT}"
+
+  branch-tag-with-hash:
+    name: "Clone from branch+hash tag (main-01c9f49)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Pull weaviate code
+        id: pull
+        uses: ./.github/actions/pull-weaviate-code
+        with:
+          docker_tag: "main-01c9f49"
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify clone
+        run: |
+          if [ ! -f "${{ steps.pull.outputs.weaviate_path }}/go.mod" ]; then
+            echo "go.mod not found — clone appears incomplete"
+            exit 1
+          fi
+
+          # Branch should be main
+          if [ "${{ steps.pull.outputs.branch }}" != "main" ]; then
+            echo "Expected branch=main, got=${{ steps.pull.outputs.branch }}"
+            exit 1
+          fi
+
+          # Verify HEAD contains the short hash
+          cd "${{ steps.pull.outputs.weaviate_path }}"
+          HEAD_SHA=$(git rev-parse HEAD)
+          if [[ "${HEAD_SHA}" != *"01c9f49"* ]]; then
+            echo "HEAD (${HEAD_SHA}) does not contain expected short hash 01c9f49"
+            exit 1
+          fi
+
+  custom-directory:
+    name: "Clone into custom directory"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Pull weaviate code into custom dir
+        id: pull
+        uses: ./.github/actions/pull-weaviate-code
+        with:
+          docker_tag: "1.36.6"
+          directory: "${{ runner.temp }}/custom-dir"
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify custom directory
+        run: |
+          EXPECTED_DIR="${{ runner.temp }}/custom-dir/weaviate"
+          if [ ! -d "${EXPECTED_DIR}" ]; then
+            echo "Expected directory ${EXPECTED_DIR} does not exist"
+            exit 1
+          fi
+
+          if [ ! -f "${EXPECTED_DIR}/go.mod" ]; then
+            echo "go.mod not found in ${EXPECTED_DIR}"
+            exit 1
+          fi
+
+          echo "weaviate_path output: ${{ steps.pull.outputs.weaviate_path }}"
+
+  directory-conflict:
+    name: "Fail when weaviate directory already exists"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Create conflicting directory
+        run: mkdir -p ./weaviate
+
+      - name: Attempt pull (should fail)
+        id: pull
+        continue-on-error: true
+        uses: ./.github/actions/pull-weaviate-code
+        with:
+          docker_tag: "1.36.6"
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify failure
+        run: |
+          if [ "${{ steps.pull.outcome }}" != "failure" ]; then
+            echo "Expected action to fail when weaviate directory already exists, but it succeeded"
+            exit 1
+          fi
+          echo "Action correctly failed due to existing weaviate directory"
+
+  nightly-tag:
+    name: "Clone from nightly tag"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Pull weaviate code
+        id: pull
+        uses: ./.github/actions/pull-weaviate-code
+        with:
+          docker_tag: "nightly"
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify clone
+        run: |
+          if [ ! -f "${{ steps.pull.outputs.weaviate_path }}/go.mod" ]; then
+            echo "go.mod not found — clone appears incomplete"
+            exit 1
+          fi
+
+          if [ "${{ steps.pull.outputs.branch }}" != "main" ]; then
+            echo "Expected branch=main, got=${{ steps.pull.outputs.branch }}"
+            exit 1
+          fi
+
+          # Commit should be a 40-char hash
+          COMMIT="${{ steps.pull.outputs.commit }}"
+          if ! [[ "${COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Expected 40-char commit hash, got=${COMMIT}"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- **get-weaviate-branch**: Resolves any Weaviate Docker tag to the exact git commit (full 40-char SHA) and branch from `weaviate/weaviate`. Reverse-engineers the tag format from `ci/push_docker.sh` to handle all variants: official releases (`1.36.6`), RC tags (`1.36.0-rc.0`), semver+hash (`1.34.19-6175eab.amd64`), preview/PR builds, branch builds (`main-01c9f49`, `stable-v1.34-519f0dc`), and special tags (`nightly`, `latest`).

- **pull-weaviate-code**: Clones `weaviate/weaviate` at the commit matching a given Docker tag. Uses `get-weaviate-branch` to resolve the tag, then performs a shallow `git fetch --depth=1` for efficiency. Validates the target path doesn't already exist and supports custom clone directories.

Both actions rely on the weaviate repo being public — git operations need no authentication. The `gh_token` input is optional and only used for the GitHub API call that resolves short commit hashes (improves rate limits from 60 to 5000 req/hr).

## Test plan

- [ ] `get-weaviate-branch-test.yml` — 11 jobs covering all tag patterns using real Docker Hub tags (semver+hash+arch, semver+hash, semver-dev+hash, preview, main branch, stable branch, official release, RC, nightly, latest, arm64 suffix)
- [ ] `pull-weaviate-code-test.yml` — 5 jobs covering release clone, branch+hash clone, custom directory, directory conflict detection, and nightly clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)