### PR TITLE
Add get-latest-branches action

### DIFF
--- a/.github/actions/get-latest-branches/action.yml
+++ b/.github/actions/get-latest-branches/action.yml
@@ -1,0 +1,104 @@
+name: get-latest-branches
+description: 'Returns the latest N version branches (e.g. stable/v1.38) of a repository, newest last, optionally including main. Ideal for matrix strategies via fromJSON.'
+inputs:
+  repository:
+    description: 'The GitHub repository (owner/name) to enumerate version branches from.'
+    required: false
+    default: 'weaviate/weaviate'
+  count:
+    description: 'Number of most-recent version branches to return.'
+    required: false
+    default: '3'
+  branch_prefix:
+    description: 'Branch namespace to enumerate (e.g. "stable/" matches stable/vX.Y branches).'
+    required: false
+    default: 'stable/'
+  include_main:
+    description: 'If "true", append the "main" branch as the newest entry.'
+    required: false
+    default: 'false'
+outputs:
+  branches_json:
+    description: 'JSON array of branch names, newest last (e.g. ["stable/v1.37","stable/v1.38"]). Use with fromJSON() for matrix strategies.'
+    value: ${{ steps.get-branches.outputs.branches_json }}
+  branches:
+    description: 'Space-separated branch names, newest last (e.g. "stable/v1.37 stable/v1.38"). Convenient for shell for-loops.'
+    value: ${{ steps.get-branches.outputs.branches }}
+  latest:
+    description: 'The single newest version branch (e.g. stable/v1.38). Independent of include_main, so it always points at the highest release branch.'
+    value: ${{ steps.get-branches.outputs.latest }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Get latest branches
+      id: get-branches
+      shell: bash
+      # Inputs are passed via env (not interpolated into the script body) so that
+      # repository/branch_prefix/etc. cannot break out of the shell context.
+      env:
+        REPOSITORY: ${{ inputs.repository }}
+        COUNT: ${{ inputs.count }}
+        BRANCH_PREFIX: ${{ inputs.branch_prefix }}
+        INCLUDE_MAIN: ${{ inputs.include_main }}
+      run: |
+        set -euo pipefail
+
+        # Public repos work without auth for ls-remote, so no token is needed.
+        repo_url="https://github.com/${REPOSITORY}.git"
+
+        if ! [[ "${COUNT}" =~ ^[1-9][0-9]*$ ]]; then
+          echo "::error::Invalid count '${COUNT}': must be a positive integer"
+          exit 1
+        fi
+
+        echo "Fetching '${BRANCH_PREFIX}v*' branches from ${repo_url}..."
+
+        # Fetch matching heads first so a transport error (bad repo, network,
+        # auth) fails loudly here instead of being misreported as "no branches
+        # found" below.
+        raw_refs=$(git ls-remote --heads "${repo_url}" "${BRANCH_PREFIX}v*")
+
+        # Keep only "<prefix>vX.Y" heads. The prefix is stripped literally
+        # (parameter expansion, not a regex) so a caller-supplied prefix
+        # containing regex metacharacters cannot alter the match. Version-sort
+        # so the newest sort last. '|| true' keeps a non-matching final line
+        # from tripping pipefail; the empty-result case is handled below.
+        branches=$(printf '%s\n' "${raw_refs}" \
+          | sed 's#.*refs/heads/##' \
+          | while IFS= read -r ref; do
+              suffix=${ref#"${BRANCH_PREFIX}"}
+              [ "${suffix}" != "${ref}" ] || continue
+              [[ "${suffix}" =~ ^v[0-9]+\.[0-9]+$ ]] && printf '%s\n' "${ref}"
+            done \
+          | sort -V \
+          | tail -n "${COUNT}" || true)
+
+        if [ -z "${branches}" ]; then
+          echo "::error::No '${BRANCH_PREFIX}v*' version branches found in ${repo_url}"
+          exit 1
+        fi
+
+        # The newest stable branch is the highest version (last line). Capture it
+        # before optionally appending main so its meaning stays predictable.
+        latest=$(printf '%s\n' "${branches}" | tail -n 1)
+
+        # Accept any capitalisation of the boolean (true/True/TRUE).
+        if [ "${INCLUDE_MAIN,,}" = "true" ]; then
+          branches="$(printf '%s\nmain' "${branches}")"
+        fi
+
+        # branches_json: a compact JSON array for fromJSON() matrix consumption.
+        # branches: a space-separated string for shell for-loops.
+        branches_json=$(printf '%s\n' "${branches}" | jq -R . | jq -s -c .)
+        branches_oneline=$(printf '%s\n' "${branches}" | paste -sd' ' -)
+
+        {
+          echo "branches_json=${branches_json}"
+          echo "branches=${branches_oneline}"
+          echo "latest=${latest}"
+        } >> "${GITHUB_OUTPUT}"
+
+        echo "--- Results ---"
+        echo "branches_json: ${branches_json}"
+        echo "branches:      ${branches_oneline}"
+        echo "latest:        ${latest}"

--- a/.github/actions/get-latest-branches/action.yml
+++ b/.github/actions/get-latest-branches/action.yml
@@ -55,14 +55,17 @@ runs:
 
         # Fetch matching heads first so a transport error (bad repo, network,
         # auth) fails loudly here instead of being misreported as "no branches
-        # found" below.
-        raw_refs=$(git ls-remote --heads "${repo_url}" "${BRANCH_PREFIX}v*")
+        # found" below. Version ordering is done by git (--sort='v:refname'),
+        # which is portable — unlike `sort -V`, which is GNU-coreutils-only and
+        # absent on macOS/BSD runners.
+        raw_refs=$(git -c 'versionsort.suffix=-' ls-remote --heads --sort='v:refname' "${repo_url}" "${BRANCH_PREFIX}v*")
 
-        # Keep only "<prefix>vX.Y" heads. The prefix is stripped literally
-        # (parameter expansion, not a regex) so a caller-supplied prefix
-        # containing regex metacharacters cannot alter the match. Version-sort
-        # so the newest sort last. '|| true' keeps a non-matching final line
-        # from tripping pipefail; the empty-result case is handled below.
+        # Keep only "<prefix>vX.Y" heads, preserving git's version order (newest
+        # last). The prefix is stripped literally: the double quotes around
+        # "${BRANCH_PREFIX}" force literal (non-glob) matching, so a caller
+        # prefix containing glob metacharacters cannot alter the match. '|| true'
+        # keeps a non-matching final line from tripping pipefail; the
+        # empty-result case is handled below.
         branches=$(printf '%s\n' "${raw_refs}" \
           | sed 's#.*refs/heads/##' \
           | while IFS= read -r ref; do
@@ -70,7 +73,6 @@ runs:
               [ "${suffix}" != "${ref}" ] || continue
               [[ "${suffix}" =~ ^v[0-9]+\.[0-9]+$ ]] && printf '%s\n' "${ref}"
             done \
-          | sort -V \
           | tail -n "${COUNT}" || true)
 
         if [ -z "${branches}" ]; then
@@ -82,8 +84,11 @@ runs:
         # before optionally appending main so its meaning stays predictable.
         latest=$(printf '%s\n' "${branches}" | tail -n 1)
 
-        # Accept any capitalisation of the boolean (true/True/TRUE).
-        if [ "${INCLUDE_MAIN,,}" = "true" ]; then
+        # Accept any capitalisation of the boolean (true/True/TRUE). Use tr
+        # rather than ${INCLUDE_MAIN,,} (Bash 4+ only) to stay portable to the
+        # Bash 3.2 shipped on macOS runners.
+        include_main_lc=$(printf '%s' "${INCLUDE_MAIN}" | tr '[:upper:]' '[:lower:]')
+        if [ "${include_main_lc}" = "true" ]; then
           branches="$(printf '%s\nmain' "${branches}")"
         fi
 

--- a/.github/workflows/get-latest-branches-test.yml
+++ b/.github/workflows/get-latest-branches-test.yml
@@ -1,0 +1,254 @@
+name: Test Get Latest Branches Action
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - '.github/actions/get-latest-branches/**'
+      - '.github/workflows/get-latest-branches-test.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  # Default inputs: weaviate/weaviate, count=3, branch_prefix=stable/, include_main=false.
+  # Assertions are structural (not hardcoded versions) so the test stays green as
+  # new stable branches are cut.
+  defaults:
+    name: "Defaults (count=3)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get latest branches
+        id: run
+        uses: ./.github/actions/get-latest-branches
+
+      - name: Verify outputs
+        run: |
+          set -euo pipefail
+          JSON='${{ steps.run.outputs.branches_json }}'
+          BRANCHES='${{ steps.run.outputs.branches }}'
+          LATEST='${{ steps.run.outputs.latest }}'
+
+          echo "branches_json: ${JSON}"
+          echo "branches:      ${BRANCHES}"
+          echo "latest:        ${LATEST}"
+
+          # Must be a JSON array of exactly 3 entries.
+          echo "${JSON}" | jq -e 'type == "array"' >/dev/null \
+            || { echo "branches_json is not a JSON array: ${JSON}"; exit 1; }
+          LEN=$(echo "${JSON}" | jq 'length')
+          if [ "${LEN}" -ne 3 ]; then
+            echo "Expected 3 branches, got ${LEN}: ${JSON}"; exit 1
+          fi
+
+          mapfile -t ARR < <(echo "${JSON}" | jq -r '.[]')
+
+          # Every entry is a full stable/vX.Y branch name.
+          for b in "${ARR[@]}"; do
+            if ! [[ "${b}" =~ ^stable/v[0-9]+\.[0-9]+$ ]]; then
+              echo "Branch '${b}' does not match ^stable/v[0-9]+\.[0-9]+$"; exit 1
+            fi
+          done
+
+          # Entries are in ascending version order (newest last).
+          SORTED=$(printf '%s\n' "${ARR[@]}" | sort -V)
+          ORIG=$(printf '%s\n' "${ARR[@]}")
+          if [ "${SORTED}" != "${ORIG}" ]; then
+            echo "Branches not in ascending version order: ${JSON}"; exit 1
+          fi
+
+          # latest equals the last (newest) element and is a stable branch.
+          if [ "${LATEST}" != "${ARR[-1]}" ]; then
+            echo "latest (${LATEST}) != last element (${ARR[-1]})"; exit 1
+          fi
+          if ! [[ "${LATEST}" =~ ^stable/v[0-9]+\.[0-9]+$ ]]; then
+            echo "latest is not a stable branch: ${LATEST}"; exit 1
+          fi
+
+          # The space-separated output is consistent with the JSON array.
+          JOINED=$(echo "${JSON}" | jq -r 'join(" ")')
+          if [ "${BRANCHES}" != "${JOINED}" ]; then
+            echo "branches ('${BRANCHES}') != JSON join ('${JOINED}')"; exit 1
+          fi
+
+  # count=1 must return a single-element array equal to latest.
+  count-one:
+    name: "count=1"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get latest branch
+        id: run
+        uses: ./.github/actions/get-latest-branches
+        with:
+          count: '1'
+
+      - name: Verify outputs
+        run: |
+          set -euo pipefail
+          JSON='${{ steps.run.outputs.branches_json }}'
+          LATEST='${{ steps.run.outputs.latest }}'
+
+          LEN=$(echo "${JSON}" | jq 'length')
+          if [ "${LEN}" -ne 1 ]; then
+            echo "Expected 1 branch, got ${LEN}: ${JSON}"; exit 1
+          fi
+          ONLY=$(echo "${JSON}" | jq -r '.[0]')
+          if [ "${ONLY}" != "${LATEST}" ]; then
+            echo "Single element (${ONLY}) != latest (${LATEST})"; exit 1
+          fi
+          if ! [[ "${ONLY}" =~ ^stable/v[0-9]+\.[0-9]+$ ]]; then
+            echo "Branch '${ONLY}' does not match stable pattern"; exit 1
+          fi
+
+  # A larger custom count must return exactly that many entries.
+  custom-count:
+    name: "count=5"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get latest branches
+        id: run
+        uses: ./.github/actions/get-latest-branches
+        with:
+          count: '5'
+
+      - name: Verify outputs
+        run: |
+          set -euo pipefail
+          JSON='${{ steps.run.outputs.branches_json }}'
+
+          LEN=$(echo "${JSON}" | jq 'length')
+          if [ "${LEN}" -ne 5 ]; then
+            echo "Expected 5 branches, got ${LEN}: ${JSON}"; exit 1
+          fi
+
+          mapfile -t ARR < <(echo "${JSON}" | jq -r '.[]')
+          for b in "${ARR[@]}"; do
+            if ! [[ "${b}" =~ ^stable/v[0-9]+\.[0-9]+$ ]]; then
+              echo "Branch '${b}' does not match stable pattern"; exit 1
+            fi
+          done
+          SORTED=$(printf '%s\n' "${ARR[@]}" | sort -V)
+          ORIG=$(printf '%s\n' "${ARR[@]}")
+          if [ "${SORTED}" != "${ORIG}" ]; then
+            echo "Branches not in ascending version order: ${JSON}"; exit 1
+          fi
+
+  # include_main=true must append 'main' as the last (newest) entry, grow the
+  # length by 1, and leave 'latest' pointing at the newest stable branch.
+  include-main:
+    name: "include_main=true"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get latest branches plus main
+        id: run
+        uses: ./.github/actions/get-latest-branches
+        with:
+          count: '3'
+          include_main: 'true'
+
+      - name: Verify outputs
+        run: |
+          set -euo pipefail
+          JSON='${{ steps.run.outputs.branches_json }}'
+          LATEST='${{ steps.run.outputs.latest }}'
+
+          echo "branches_json: ${JSON}"
+
+          # 3 stable branches + main.
+          LEN=$(echo "${JSON}" | jq 'length')
+          if [ "${LEN}" -ne 4 ]; then
+            echo "Expected 4 entries (3 stable + main), got ${LEN}: ${JSON}"; exit 1
+          fi
+
+          # main is appended last.
+          LAST=$(echo "${JSON}" | jq -r '.[-1]')
+          if [ "${LAST}" != "main" ]; then
+            echo "Expected last element 'main', got '${LAST}'"; exit 1
+          fi
+
+          # Everything before main is an ascending run of stable branches.
+          mapfile -t STABLE < <(echo "${JSON}" | jq -r '.[:-1][]')
+          for b in "${STABLE[@]}"; do
+            if ! [[ "${b}" =~ ^stable/v[0-9]+\.[0-9]+$ ]]; then
+              echo "Non-stable entry before main: '${b}'"; exit 1
+            fi
+          done
+          SORTED=$(printf '%s\n' "${STABLE[@]}" | sort -V)
+          ORIG=$(printf '%s\n' "${STABLE[@]}")
+          if [ "${SORTED}" != "${ORIG}" ]; then
+            echo "Stable entries not in ascending order: ${JSON}"; exit 1
+          fi
+
+          # latest stays a stable branch — never 'main'.
+          if [ "${LATEST}" = "main" ]; then
+            echo "latest should not be main"; exit 1
+          fi
+          if ! [[ "${LATEST}" =~ ^stable/v[0-9]+\.[0-9]+$ ]]; then
+            echo "latest is not a stable branch: ${LATEST}"; exit 1
+          fi
+
+  # An invalid count must fail the action (not silently produce an empty matrix).
+  invalid-count:
+    name: "Invalid count fails"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get latest branches (invalid count)
+        id: run
+        continue-on-error: true
+        uses: ./.github/actions/get-latest-branches
+        with:
+          count: '0'
+
+      - name: Verify the action failed
+        run: |
+          if [ "${{ steps.run.outcome }}" != "failure" ]; then
+            echo "Expected action to fail for count=0, outcome=${{ steps.run.outcome }}"; exit 1
+          fi
+
+  # End-to-end proof that the JSON output drives a matrix via fromJSON().
+  matrix-source:
+    name: "Matrix source"
+    runs-on: ubuntu-latest
+    outputs:
+      branches_json: ${{ steps.run.outputs.branches_json }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get latest branches plus main
+        id: run
+        uses: ./.github/actions/get-latest-branches
+        with:
+          count: '2'
+          include_main: 'true'
+
+  matrix-consume:
+    name: "Matrix consume"
+    needs: matrix-source
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJSON(needs.matrix-source.outputs.branches_json) }}
+    steps:
+      - name: Verify matrix value
+        run: |
+          set -euo pipefail
+          B='${{ matrix.branch }}'
+          echo "Matrix branch: ${B}"
+          if [ -z "${B}" ]; then
+            echo "Empty matrix branch"; exit 1
+          fi
+          if ! [[ "${B}" =~ ^(stable/v[0-9]+\.[0-9]+|main)$ ]]; then
+            echo "Unexpected matrix branch: ${B}"; exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Python virtual environments
+.venv/
+venv/
+
+# Python bytecode
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ jobs:
 
 ### Behavior
 - Uses `git ls-remote` against the public repository — no token required.
-- Branches are version-sorted (`sort -V`), so `stable/v1.9` correctly precedes `stable/v1.10`, and the newest branches are kept.
+- Branches are version-sorted by git (`ls-remote --sort='v:refname'`), so `stable/v1.9` correctly precedes `stable/v1.10`, and the newest branches are kept. Using git's sort avoids depending on GNU `sort -V`, which is unavailable on macOS/BSD runners.
 - `main` (when `include_main: 'true'`) is always appended last, since it is ahead of every release branch.
 - The action fails (exit 1) if `count` is not a positive integer, or if no matching version branches are found — preventing a silently empty matrix.
 

--- a/README.md
+++ b/README.md
@@ -240,3 +240,81 @@ jobs:
 - Always use the stop action in a cleanup step (with `if: always()`) to ensure logs are properly stopped
 - The docker-compose file must be accessible in the workspace when using Docker mode
 
+## get-latest-branches
+
+### Description
+Returns the latest N version branches (e.g. `stable/v1.38`) of a repository, ordered oldest → newest, with optional inclusion of the `main` branch. The primary output is a JSON array designed to feed a `matrix` strategy via `fromJSON()`.
+
+### Inputs
+- `repository` (optional): The GitHub repository (`owner/name`) to enumerate version branches from. Default: `weaviate/weaviate`.
+- `count` (optional): Number of most-recent version branches to return. Default: `3`.
+- `branch_prefix` (optional): Branch namespace to enumerate (e.g. `stable/` matches `stable/vX.Y` branches). Default: `stable/`.
+- `include_main` (optional): If `'true'`, append the `main` branch as the newest entry. Default: `'false'`.
+
+### Outputs
+- `branches_json`: JSON array of branch names, newest last (e.g. `["stable/v1.37","stable/v1.38"]`). Use with `fromJSON()` for matrix strategies.
+- `branches`: Space-separated branch names, newest last (e.g. `stable/v1.37 stable/v1.38`). Convenient for shell `for`-loops.
+- `latest`: The single newest version branch (e.g. `stable/v1.38`). Independent of `include_main`, so it always points at the highest release branch.
+
+### Usage
+
+#### Matrix strategy (primary use case)
+```yaml
+name: Test Across Latest Weaviate Branches
+on: [push]
+
+jobs:
+  resolve-branches:
+    runs-on: ubuntu-latest
+    outputs:
+      branches_json: ${{ steps.branches.outputs.branches_json }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get latest branches
+        id: branches
+        uses: weaviate/github-common-actions/.github/actions/get-latest-branches@main
+        with:
+          count: '3'
+          include_main: 'true'
+
+  test:
+    needs: resolve-branches
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJSON(needs.resolve-branches.outputs.branches_json) }}
+    steps:
+      - name: Show branch
+        run: echo "Testing against ${{ matrix.branch }}"
+```
+
+#### Shell loop
+```yaml
+      - name: Get latest branches
+        id: branches
+        uses: weaviate/github-common-actions/.github/actions/get-latest-branches@main
+        with:
+          count: '5'
+
+      - name: Iterate
+        run: |
+          for branch in ${{ steps.branches.outputs.branches }}; do
+            echo "Branch: ${branch}"
+          done
+          echo "Latest: ${{ steps.branches.outputs.latest }}"
+```
+
+### Examples
+- `count: '3'` against `weaviate/weaviate` → `["stable/v1.36","stable/v1.37","stable/v1.38"]`
+- `count: '3'` with `include_main: 'true'` → `["stable/v1.36","stable/v1.37","stable/v1.38","main"]`
+- `count: '1'` → `["stable/v1.38"]`
+
+### Behavior
+- Uses `git ls-remote` against the public repository — no token required.
+- Branches are version-sorted (`sort -V`), so `stable/v1.9` correctly precedes `stable/v1.10`, and the newest branches are kept.
+- `main` (when `include_main: 'true'`) is always appended last, since it is ahead of every release branch.
+- The action fails (exit 1) if `count` is not a positive integer, or if no matching version branches are found — preventing a silently empty matrix.
+


### PR DESCRIPTION
## Motivation

CI workflows that need to test against "the last N Weaviate release branches" currently hardcode branch names like `stable/v1.36`, `stable/v1.37`, `stable/v1.38`. Every new release cut forces a manual edit across every consuming workflow, and a forgotten update silently tests against stale branches. This action resolves those branches dynamically so a matrix can stay current with zero maintenance.

Note this is distinct from the existing `get-latest-weaviate-version` action, which returns the newest release *tag* (e.g. `1.38.2`). This one enumerates release *branches* and is shaped specifically to drive a `fromJSON()` matrix.

## Approach

A composite action runs `git ls-remote --heads` against the target repo (default `weaviate/weaviate`), filters to `stable/vX.Y` heads, version-sorts them, and keeps the newest `count`. It emits three outputs for different consumers: `branches_json` (the primary one, for `fromJSON()` matrices), `branches` (space-separated, for shell loops), and `latest` (the single newest stable branch).

Key design decisions worth calling out:

- **`latest` is captured before `main` is appended**, so `include_main: 'true'` never changes what `latest` means — it always points at the highest release branch. This keeps the two concepts (newest *stable* vs. the bleeding edge) independent.
- **No auth/token required**: `ls-remote` works against public repos unauthenticated, so the action has zero secret dependencies and can run anywhere.
- **Version sort, not lexical**: `sort -V` ensures `stable/v1.9` precedes `stable/v1.10` correctly.

## Key areas for review

- `action.yml` (fetch-then-filter pipeline) — Two intentional robustness choices: (1) `ls-remote` is run *before* the filtering pipeline so a transport error (bad repo / network / auth) fails loudly instead of being swallowed and reported as the misleading "no branches found"; (2) the prefix is stripped via parameter expansion (`${ref#"${BRANCH_PREFIX}"}`), not a regex, so a caller-supplied `branch_prefix` containing regex metacharacters can't alter matching.
- `action.yml` (inputs) — inputs are passed via `env`, not interpolated into the script body, to prevent any shell-injection through input values.
- `action.yml` (`${INCLUDE_MAIN,,}`) — lower-cases the boolean so `true`/`True`/`TRUE` all work.

## Risks and mitigations

- **Silently empty matrix**: an empty branch list would produce a matrix with no jobs, which looks like a pass. Mitigated by failing the action (exit 1) when no matching branches are found, and by validating `count` is a positive integer up front (`count: '0'` fails rather than returning everything).
- **`pipefail` tripping on the filter loop**: the filtering can legitimately discard the last line; `|| true` on the pipeline prevents that from being mistaken for a real error, and the genuine empty-result case is still caught by the explicit check below it.

## Testing

The paired test workflow (`get-latest-branches-test.yml`) runs against the real `weaviate/weaviate` repo. Assertions are **structural rather than hardcoded versions**, so the suite stays green as new stable branches are cut. Coverage:

- **Defaults (count=3)**: array length, every entry matches `^stable/v[0-9]+\.[0-9]+$`, ascending version order, `latest` equals the last element, and `branches` string is consistent with the JSON.
- **count=1**: single-element array equal to `latest`.
- **count=5**: exactly 5 entries, all valid and ordered.
- **include_main=true**: length grows by 1, `main` is appended last, the stable prefix is still ascending, and `latest` is never `main`.
- **Invalid count (count=0)**: action must fail (uses `continue-on-error` then asserts `outcome == failure`) — guards the empty-matrix risk above.
- **Matrix smoke test**: end-to-end proof that `branches_json` actually drives a downstream `matrix` via `fromJSON()`, including the `main` entry.

## Notes

Also adds a `.gitignore` (Python venv / bytecode) since the repo previously had none, and a README section documenting inputs, outputs, the matrix usage pattern, and the shell-loop pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
