### PR TITLE
Add get-branch-docker-tag action

### DIFF
--- a/.github/actions/get-branch-docker-tag/action.yml
+++ b/.github/actions/get-branch-docker-tag/action.yml
@@ -17,7 +17,7 @@ inputs:
     required: false
     default: ''
   max_depth:
-    description: 'How many commits back (from the branch tip) to search for a published image before failing.'
+    description: 'How many commits back (from the branch tip) to search for a published image before failing. Must be 1-100 (the GitHub commits API caps a page at 100).'
     required: false
     default: '30'
 outputs:
@@ -56,8 +56,10 @@ runs:
       run: |
         set -euo pipefail
 
-        if ! [[ "${MAX_DEPTH}" =~ ^[1-9][0-9]*$ ]]; then
-          echo "::error::Invalid max_depth '${MAX_DEPTH}': must be a positive integer"
+        # The GitHub commits API caps per_page at 100, so a larger max_depth
+        # would silently search fewer commits than requested — reject it instead.
+        if ! [[ "${MAX_DEPTH}" =~ ^[1-9][0-9]*$ ]] || [ "${MAX_DEPTH}" -gt 100 ]; then
+          echo "::error::Invalid max_depth '${MAX_DEPTH}': must be an integer between 1 and 100"
           exit 1
         fi
         if [ -z "${BRANCH}" ]; then
@@ -69,6 +71,13 @@ runs:
         RAW="https://raw.githubusercontent.com/${REPOSITORY}"
         HUB="https://hub.docker.com/v2/repositories/${REGISTRY}/tags"
         branch="${BRANCH#refs/heads/}"
+        # Re-check after stripping: an input like "refs/heads/" collapses to empty,
+        # and an empty sha would make the commits API fall back to the default
+        # branch and silently resolve the wrong image.
+        if [ -z "${branch}" ]; then
+          echo "::error::branch '${BRANCH}' resolves to an empty ref after stripping 'refs/heads/'"
+          exit 1
+        fi
 
         echo "Resolving latest available multi-arch image for '${branch}' (repo ${REPOSITORY}, registry ${REGISTRY}, max_depth ${MAX_DEPTH})..."
 
@@ -83,7 +92,7 @@ runs:
         #     tag alone collides across branches sharing a version).
 
         # Recent commits on the branch, newest first.
-        gh_curl=(curl -fsS --retry 3 --retry-delay 2 -H "Accept: application/vnd.github+json")
+        gh_curl=(curl -fsS --retry 3 --retry-delay 2 --max-time 30 -H "Accept: application/vnd.github+json")
         if [ -n "${GH_TOKEN}" ]; then
           gh_curl+=(-H "Authorization: Bearer ${GH_TOKEN}")
         fi

--- a/.github/actions/get-branch-docker-tag/action.yml
+++ b/.github/actions/get-branch-docker-tag/action.yml
@@ -142,9 +142,26 @@ runs:
         idx=0
         for full in "${shas[@]}"; do
           short="${full:0:7}"
-          # The version this commit was (or would be) built with.
-          if ! ver=$(curl -fsSL --retry 3 --retry-delay 2 --max-time 30 "${RAW}/${full}/openapi-specs/schema.json" | jq -r '.info.version // empty') || [ -z "${ver}" ]; then
-            echo "  [${idx}] ${short} : no schema.json/version, skipping"
+          # The version this commit was (or would be) built with. Capture the
+          # HTTP status so a transient fetch failure (5xx/000/timeout, after
+          # retries) is not mistaken for "no schema.json" and silently skipped —
+          # that could return a stale, non-latest tag. Only a definitive 404
+          # means the file is genuinely absent at this commit; anything else
+          # fails closed. '|| true' keeps a hard curl failure from tripping set -e.
+          resp=$(curl -s --retry 3 --retry-delay 2 --retry-all-errors --max-time 30 -w $'\n%{http_code}' "${RAW}/${full}/openapi-specs/schema.json" || true)
+          schema_code="${resp##*$'\n'}"
+          schema_body="${resp%$'\n'*}"
+          if [ "${schema_code}" = "404" ]; then
+            echo "  [${idx}] ${short} : no schema.json (404), skipping"
+            idx=$((idx + 1)); continue
+          fi
+          if [ "${schema_code}" != "200" ]; then
+            echo "::error::Failed to fetch schema.json for ${short} (HTTP ${schema_code}); cannot reliably determine the version (refusing to skip and risk returning a stale tag)"
+            exit 1
+          fi
+          ver=$(printf '%s' "${schema_body}" | jq -r '.info.version // empty')
+          if [ -z "${ver}" ]; then
+            echo "  [${idx}] ${short} : schema.json has no version, skipping"
             idx=$((idx + 1)); continue
           fi
           mm=$(printf '%s' "${ver}" | grep -oE '^[0-9]+\.[0-9]+' || true)

--- a/.github/actions/get-branch-docker-tag/action.yml
+++ b/.github/actions/get-branch-docker-tag/action.yml
@@ -66,6 +66,16 @@ runs:
           echo "::error::branch must not be empty"
           exit 1
         fi
+        # Empty repository/registry would build invalid API/registry URLs and
+        # surface as a misleading "does the branch exist?" error.
+        if [ -z "${REPOSITORY}" ]; then
+          echo "::error::repository must not be empty"
+          exit 1
+        fi
+        if [ -z "${REGISTRY}" ]; then
+          echo "::error::registry must not be empty"
+          exit 1
+        fi
 
         GH_API="https://api.github.com/repos/${REPOSITORY}"
         RAW="https://raw.githubusercontent.com/${REPOSITORY}"
@@ -136,13 +146,20 @@ runs:
             idx=$((idx + 1)); continue
           fi
           candidate="${ver}-${short}"
-          # '|| true' so a transient non-200 (incl. curl exit on connection error)
-          # doesn't trip set -e; we only act on an explicit 200.
-          code=$(curl -s --retry 3 --retry-delay 2 -o /dev/null -w "%{http_code}" --max-time 30 "${HUB}/${candidate}" || true)
+          # --retry-all-errors also retries connection failures (000); '|| true'
+          # keeps a hard curl failure from tripping set -e (code stays 000 then).
+          code=$(curl -s --retry 3 --retry-delay 2 --retry-all-errors -o /dev/null -w "%{http_code}" --max-time 30 "${HUB}/${candidate}" || true)
           echo "  [${idx}] ${short} -> ${candidate} : ${code}"
           if [ "${code}" = "200" ]; then
             docker_tag="${candidate}"; version="${ver}"; sha="${short}"; commit="${full}"; commits_behind="${idx}"
             break
+          elif [ "${code}" != "404" ]; then
+            # Only a definitive 404 means "not built". An ambiguous response
+            # (5xx/429/000/...) for a tag that may well exist must not be treated
+            # as missing — that would silently fall back to an older image and
+            # return a non-latest result. Fail closed instead.
+            echo "::error::Docker Hub returned HTTP ${code} for tag '${candidate}'; cannot reliably determine availability (refusing to silently fall back to an older image)"
+            exit 1
           fi
           idx=$((idx + 1))
         done

--- a/.github/actions/get-branch-docker-tag/action.yml
+++ b/.github/actions/get-branch-docker-tag/action.yml
@@ -106,7 +106,20 @@ runs:
           exit 1
         fi
 
-        # Walk newest-first: first commit with a published multi-arch semver tag wins.
+        # Restrict the search to the branch's own version line so a fallback
+        # cannot cross the branch point into an ancestor line (e.g. resolving
+        # stable/v1.36 to a 1.35.x build, which is reachable from the branch and
+        # interleaved in its commit history). For stable/vX.Y the line is X.Y
+        # from the name; otherwise it is the major.minor of the branch tip's
+        # version (captured from the first readable commit). Off-line commits are
+        # skipped (not stopped at), since the lines can interleave.
+        expected_mm=""
+        if [[ "${branch}" =~ ^stable/v([0-9]+\.[0-9]+)$ ]]; then
+          expected_mm="${BASH_REMATCH[1]}"
+        fi
+
+        # Walk newest-first: first commit on the branch's version line with a
+        # published multi-arch semver tag wins.
         docker_tag=""; version=""; sha=""; commit=""; commits_behind=""
         idx=0
         for full in "${shas[@]}"; do
@@ -114,6 +127,12 @@ runs:
           # The version this commit was (or would be) built with.
           if ! ver=$(curl -fsSL --retry 3 --retry-delay 2 --max-time 30 "${RAW}/${full}/openapi-specs/schema.json" | jq -r '.info.version // empty') || [ -z "${ver}" ]; then
             echo "  [${idx}] ${short} : no schema.json/version, skipping"
+            idx=$((idx + 1)); continue
+          fi
+          mm=$(printf '%s' "${ver}" | grep -oE '^[0-9]+\.[0-9]+' || true)
+          if [ -z "${expected_mm}" ]; then expected_mm="${mm}"; fi
+          if [ "${mm}" != "${expected_mm}" ]; then
+            echo "  [${idx}] ${short} -> ${ver} : skipping (version line ${mm:-?} != ${expected_mm})"
             idx=$((idx + 1)); continue
           fi
           candidate="${ver}-${short}"
@@ -129,7 +148,7 @@ runs:
         done
 
         if [ -z "${docker_tag}" ]; then
-          echo "::error::No published multi-arch image found for branch '${branch}' within the last ${MAX_DEPTH} commits in ${REGISTRY}"
+          echo "::error::No published ${expected_mm:+${expected_mm}.x }multi-arch image found for branch '${branch}' within the last ${MAX_DEPTH} commits in ${REGISTRY}"
           exit 1
         fi
 

--- a/.github/actions/get-branch-docker-tag/action.yml
+++ b/.github/actions/get-branch-docker-tag/action.yml
@@ -1,0 +1,147 @@
+name: get-branch-docker-tag
+description: 'Resolves a Weaviate git branch (main or stable/vX.Y) to the latest AVAILABLE multi-arch Docker tag (e.g. 1.38.0-rc.1-8269596) published to Docker Hub, walking back the branch history when the newest commit has no image yet.'
+inputs:
+  branch:
+    description: 'Git branch to resolve, e.g. "main" or "stable/v1.38" (as emitted by get-latest-branches). A leading "refs/heads/" is stripped.'
+    required: true
+  repository:
+    description: 'GitHub repository (owner/name) whose commits and openapi-specs/schema.json are read.'
+    required: false
+    default: 'weaviate/weaviate'
+  registry:
+    description: 'Docker Hub repository (namespace/name) whose tags are checked for availability.'
+    required: false
+    default: 'semitechnologies/weaviate'
+  gh_token:
+    description: 'GitHub token for the commits API (avoids rate limits). Optional but recommended.'
+    required: false
+    default: ''
+  max_depth:
+    description: 'How many commits back (from the branch tip) to search for a published image before failing.'
+    required: false
+    default: '30'
+outputs:
+  docker_tag:
+    description: 'Latest available multi-arch semver tag for the branch, e.g. 1.38.0-rc.1-8269596.'
+    value: ${{ steps.resolve.outputs.docker_tag }}
+  version:
+    description: 'The Weaviate version part of the tag, e.g. 1.38.0-rc.1.'
+    value: ${{ steps.resolve.outputs.version }}
+  sha:
+    description: '7-char short commit the image was built from, e.g. 8269596.'
+    value: ${{ steps.resolve.outputs.sha }}
+  commit:
+    description: 'Full 40-char commit SHA the image was built from.'
+    value: ${{ steps.resolve.outputs.commit }}
+  is_fallback:
+    description: '"true" if the branch tip had no published image and an older commit was used, otherwise "false".'
+    value: ${{ steps.resolve.outputs.is_fallback }}
+  commits_behind:
+    description: 'How many commits behind the branch tip the resolved image is (0 = the tip itself).'
+    value: ${{ steps.resolve.outputs.commits_behind }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Resolve latest available Docker tag for branch
+      id: resolve
+      shell: bash
+      # Inputs are passed via env (not interpolated into the script body) so that
+      # branch/repository/registry values cannot break out of the shell context.
+      env:
+        BRANCH: ${{ inputs.branch }}
+        REPOSITORY: ${{ inputs.repository }}
+        REGISTRY: ${{ inputs.registry }}
+        GH_TOKEN: ${{ inputs.gh_token }}
+        MAX_DEPTH: ${{ inputs.max_depth }}
+      run: |
+        set -euo pipefail
+
+        if ! [[ "${MAX_DEPTH}" =~ ^[1-9][0-9]*$ ]]; then
+          echo "::error::Invalid max_depth '${MAX_DEPTH}': must be a positive integer"
+          exit 1
+        fi
+        if [ -z "${BRANCH}" ]; then
+          echo "::error::branch must not be empty"
+          exit 1
+        fi
+
+        GH_API="https://api.github.com/repos/${REPOSITORY}"
+        RAW="https://raw.githubusercontent.com/${REPOSITORY}"
+        HUB="https://hub.docker.com/v2/repositories/${REGISTRY}/tags"
+        branch="${BRANCH#refs/heads/}"
+
+        echo "Resolving latest available multi-arch image for '${branch}' (repo ${REPOSITORY}, registry ${REGISTRY}, max_depth ${MAX_DEPTH})..."
+
+        # Why git-anchored exact-tag checks (not Docker Hub tag listings):
+        #   * push_docker.sh publishes a multi-arch tag "<version>-<short-sha>" on every
+        #     merge/PR build; <version> comes from openapi-specs/schema.json at that commit.
+        #   * Only some commits are built, so the newest AVAILABLE image is often a few
+        #     commits behind the branch tip — hence the walk.
+        #   * Docker Hub's /tags?name= listing endpoint is slow/unreliable for common
+        #     prefixes (504/timeout); the exact /tags/<tag> endpoint is reliable. Walking
+        #     the branch's own commits also keeps the result branch-precise (the semver
+        #     tag alone collides across branches sharing a version).
+
+        # Recent commits on the branch, newest first.
+        gh_curl=(curl -fsS --retry 3 --retry-delay 2 -H "Accept: application/vnd.github+json")
+        if [ -n "${GH_TOKEN}" ]; then
+          gh_curl+=(-H "Authorization: Bearer ${GH_TOKEN}")
+        fi
+        if ! commits_json=$("${gh_curl[@]}" "${GH_API}/commits?sha=${branch}&per_page=${MAX_DEPTH}"); then
+          echo "::error::Failed to list commits for branch '${branch}' in ${REPOSITORY} (does the branch exist?)"
+          exit 1
+        fi
+        mapfile -t shas < <(printf '%s' "${commits_json}" | jq -r '.[].sha')
+        if [ "${#shas[@]}" -eq 0 ]; then
+          echo "::error::No commits found for branch '${branch}' in ${REPOSITORY}"
+          exit 1
+        fi
+
+        # Walk newest-first: first commit with a published multi-arch semver tag wins.
+        docker_tag=""; version=""; sha=""; commit=""; commits_behind=""
+        idx=0
+        for full in "${shas[@]}"; do
+          short="${full:0:7}"
+          # The version this commit was (or would be) built with.
+          if ! ver=$(curl -fsSL --retry 3 --retry-delay 2 --max-time 30 "${RAW}/${full}/openapi-specs/schema.json" | jq -r '.info.version // empty') || [ -z "${ver}" ]; then
+            echo "  [${idx}] ${short} : no schema.json/version, skipping"
+            idx=$((idx + 1)); continue
+          fi
+          candidate="${ver}-${short}"
+          # '|| true' so a transient non-200 (incl. curl exit on connection error)
+          # doesn't trip set -e; we only act on an explicit 200.
+          code=$(curl -s --retry 3 --retry-delay 2 -o /dev/null -w "%{http_code}" --max-time 30 "${HUB}/${candidate}" || true)
+          echo "  [${idx}] ${short} -> ${candidate} : ${code}"
+          if [ "${code}" = "200" ]; then
+            docker_tag="${candidate}"; version="${ver}"; sha="${short}"; commit="${full}"; commits_behind="${idx}"
+            break
+          fi
+          idx=$((idx + 1))
+        done
+
+        if [ -z "${docker_tag}" ]; then
+          echo "::error::No published multi-arch image found for branch '${branch}' within the last ${MAX_DEPTH} commits in ${REGISTRY}"
+          exit 1
+        fi
+
+        is_fallback=false
+        if [ "${commits_behind}" -gt 0 ]; then
+          is_fallback=true
+        fi
+
+        {
+          echo "docker_tag=${docker_tag}"
+          echo "version=${version}"
+          echo "sha=${sha}"
+          echo "commit=${commit}"
+          echo "is_fallback=${is_fallback}"
+          echo "commits_behind=${commits_behind}"
+        } >> "${GITHUB_OUTPUT}"
+
+        echo "--- Results ---"
+        echo "docker_tag:     ${docker_tag}"
+        echo "version:        ${version}"
+        echo "sha:            ${sha}"
+        echo "commit:         ${commit}"
+        echo "is_fallback:    ${is_fallback}"
+        echo "commits_behind: ${commits_behind}"

--- a/.github/actions/get-branch-docker-tag/action.yml
+++ b/.github/actions/get-branch-docker-tag/action.yml
@@ -101,16 +101,24 @@ runs:
         #     the branch's own commits also keeps the result branch-precise (the semver
         #     tag alone collides across branches sharing a version).
 
-        # Recent commits on the branch, newest first.
+        # Recent commits on the branch, newest first. URL-encode the ref so a
+        # branch name containing query-significant characters (&, =, ...) cannot
+        # alter the request.
+        branch_enc=$(jq -rn --arg b "${branch}" '$b|@uri')
         gh_curl=(curl -fsS --retry 3 --retry-delay 2 --max-time 30 -H "Accept: application/vnd.github+json")
         if [ -n "${GH_TOKEN}" ]; then
           gh_curl+=(-H "Authorization: Bearer ${GH_TOKEN}")
         fi
-        if ! commits_json=$("${gh_curl[@]}" "${GH_API}/commits?sha=${branch}&per_page=${MAX_DEPTH}"); then
-          echo "::error::Failed to list commits for branch '${branch}' in ${REPOSITORY} (does the branch exist?)"
+        if ! commits_json=$("${gh_curl[@]}" "${GH_API}/commits?sha=${branch_enc}&per_page=${MAX_DEPTH}"); then
+          echo "::error::Failed to list commits for branch '${branch}' in ${REPOSITORY} (check the branch exists, the repository is correct, and the token/rate limit)"
           exit 1
         fi
-        mapfile -t shas < <(printf '%s' "${commits_json}" | jq -r '.[].sha')
+        # Read SHAs into an array without mapfile (Bash 4+) to stay portable to
+        # the Bash 3.2 shipped on macOS runners.
+        shas=()
+        while IFS= read -r sha_line; do
+          shas+=("${sha_line}")
+        done < <(printf '%s' "${commits_json}" | jq -r '.[].sha')
         if [ "${#shas[@]}" -eq 0 ]; then
           echo "::error::No commits found for branch '${branch}' in ${REPOSITORY}"
           exit 1

--- a/.github/workflows/get-branch-docker-tag-test.yml
+++ b/.github/workflows/get-branch-docker-tag-test.yml
@@ -65,7 +65,7 @@ jobs:
             echo "commits_behind=0 but is_fallback=${FB}"; exit 1
           fi
           # CORE GUARANTEE: the resolved tag is actually pullable from the registry.
-          CODE=$(curl -s --retry 3 --retry-delay 2 --max-time 30 -o /dev/null -w "%{http_code}" \
+          CODE=$(curl -s --retry 3 --retry-delay 2 --retry-all-errors --max-time 30 -o /dev/null -w "%{http_code}" \
             "https://hub.docker.com/v2/repositories/semitechnologies/weaviate/tags/${TAG}" || true)
           if [ "${CODE}" != "200" ]; then
             echo "docker_tag '${TAG}' is not available in the registry (HTTP ${CODE})"; exit 1
@@ -101,7 +101,7 @@ jobs:
           if ! [[ "${VER}" =~ ^1\.36\.[0-9]+$ ]]; then
             echo "version '${VER}' is not 1.36.x"; exit 1
           fi
-          CODE=$(curl -s --retry 3 --retry-delay 2 --max-time 30 -o /dev/null -w "%{http_code}" \
+          CODE=$(curl -s --retry 3 --retry-delay 2 --retry-all-errors --max-time 30 -o /dev/null -w "%{http_code}" \
             "https://hub.docker.com/v2/repositories/semitechnologies/weaviate/tags/${TAG}" || true)
           if [ "${CODE}" != "200" ]; then
             echo "docker_tag '${TAG}' is not available in the registry (HTTP ${CODE})"; exit 1

--- a/.github/workflows/get-branch-docker-tag-test.yml
+++ b/.github/workflows/get-branch-docker-tag-test.yml
@@ -65,8 +65,8 @@ jobs:
             echo "commits_behind=0 but is_fallback=${FB}"; exit 1
           fi
           # CORE GUARANTEE: the resolved tag is actually pullable from the registry.
-          CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-            "https://hub.docker.com/v2/repositories/semitechnologies/weaviate/tags/${TAG}")
+          CODE=$(curl -s --retry 3 --retry-delay 2 --max-time 30 -o /dev/null -w "%{http_code}" \
+            "https://hub.docker.com/v2/repositories/semitechnologies/weaviate/tags/${TAG}" || true)
           if [ "${CODE}" != "200" ]; then
             echo "docker_tag '${TAG}' is not available in the registry (HTTP ${CODE})"; exit 1
           fi
@@ -101,8 +101,8 @@ jobs:
           if ! [[ "${VER}" =~ ^1\.36\.[0-9]+$ ]]; then
             echo "version '${VER}' is not 1.36.x"; exit 1
           fi
-          CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-            "https://hub.docker.com/v2/repositories/semitechnologies/weaviate/tags/${TAG}")
+          CODE=$(curl -s --retry 3 --retry-delay 2 --max-time 30 -o /dev/null -w "%{http_code}" \
+            "https://hub.docker.com/v2/repositories/semitechnologies/weaviate/tags/${TAG}" || true)
           if [ "${CODE}" != "200" ]; then
             echo "docker_tag '${TAG}' is not available in the registry (HTTP ${CODE})"; exit 1
           fi

--- a/.github/workflows/get-branch-docker-tag-test.yml
+++ b/.github/workflows/get-branch-docker-tag-test.yml
@@ -1,0 +1,152 @@
+name: Test Get Branch Docker Tag Action
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - '.github/actions/get-branch-docker-tag/**'
+      - '.github/workflows/get-branch-docker-tag-test.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  # main resolves to a semver multi-arch tag that is actually pullable.
+  # Assertions are structural (no hardcoded versions) so the test stays green over time.
+  main:
+    name: "branch: main"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve docker tag
+        id: run
+        uses: ./.github/actions/get-branch-docker-tag
+        with:
+          branch: main
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify outputs
+        run: |
+          set -euo pipefail
+          TAG='${{ steps.run.outputs.docker_tag }}'
+          VER='${{ steps.run.outputs.version }}'
+          SHA='${{ steps.run.outputs.sha }}'
+          COMMIT='${{ steps.run.outputs.commit }}'
+          FB='${{ steps.run.outputs.is_fallback }}'
+          CB='${{ steps.run.outputs.commits_behind }}'
+          echo "tag=${TAG} ver=${VER} sha=${SHA} commit=${COMMIT} is_fallback=${FB} commits_behind=${CB}"
+
+          # docker_tag shape: <major.minor.patch>[-prerelease]-<7hex>
+          if ! [[ "${TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?-[0-9a-f]{7}$ ]]; then
+            echo "docker_tag '${TAG}' does not match expected pattern"; exit 1
+          fi
+          # commit is a full 40-char SHA and sha is its 7-char prefix
+          if ! [[ "${COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "commit '${COMMIT}' is not a 40-char SHA"; exit 1
+          fi
+          if [ "${SHA}" != "${COMMIT:0:7}" ]; then
+            echo "sha '${SHA}' != commit prefix '${COMMIT:0:7}'"; exit 1
+          fi
+          # docker_tag == version + "-" + sha
+          if [ "${TAG}" != "${VER}-${SHA}" ]; then
+            echo "docker_tag '${TAG}' != '${VER}-${SHA}'"; exit 1
+          fi
+          # is_fallback is a boolean consistent with commits_behind
+          case "${FB}" in true|false) ;; *) echo "is_fallback not boolean: ${FB}"; exit 1;; esac
+          if ! [[ "${CB}" =~ ^[0-9]+$ ]]; then
+            echo "commits_behind not a non-negative integer: ${CB}"; exit 1
+          fi
+          if [ "${CB}" -gt 0 ] && [ "${FB}" != "true" ]; then
+            echo "commits_behind>0 but is_fallback=${FB}"; exit 1
+          fi
+          if [ "${CB}" -eq 0 ] && [ "${FB}" != "false" ]; then
+            echo "commits_behind=0 but is_fallback=${FB}"; exit 1
+          fi
+          # CORE GUARANTEE: the resolved tag is actually pullable from the registry.
+          CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            "https://hub.docker.com/v2/repositories/semitechnologies/weaviate/tags/${TAG}")
+          if [ "${CODE}" != "200" ]; then
+            echo "docker_tag '${TAG}' is not available in the registry (HTTP ${CODE})"; exit 1
+          fi
+          echo "OK: ${TAG} is pullable (commits_behind=${CB})"
+
+  # A mature stable branch resolves to its own version line and is pullable.
+  stable:
+    name: "branch: stable/v1.36"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve docker tag
+        id: run
+        uses: ./.github/actions/get-branch-docker-tag
+        with:
+          branch: stable/v1.36
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify outputs
+        run: |
+          set -euo pipefail
+          TAG='${{ steps.run.outputs.docker_tag }}'
+          VER='${{ steps.run.outputs.version }}'
+          SHA='${{ steps.run.outputs.sha }}'
+          echo "tag=${TAG} ver=${VER} sha=${SHA}"
+
+          # stable/v1.36 must resolve to a 1.36.x tag (its own version line).
+          if ! [[ "${TAG}" =~ ^1\.36\.[0-9]+-[0-9a-f]{7}$ ]]; then
+            echo "docker_tag '${TAG}' is not a 1.36.x-<sha> tag"; exit 1
+          fi
+          if ! [[ "${VER}" =~ ^1\.36\.[0-9]+$ ]]; then
+            echo "version '${VER}' is not 1.36.x"; exit 1
+          fi
+          CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            "https://hub.docker.com/v2/repositories/semitechnologies/weaviate/tags/${TAG}")
+          if [ "${CODE}" != "200" ]; then
+            echo "docker_tag '${TAG}' is not available in the registry (HTTP ${CODE})"; exit 1
+          fi
+          echo "OK: ${TAG} is pullable"
+
+  # A non-existent branch must fail the action (commits API 404).
+  invalid-branch:
+    name: "Invalid branch fails"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve docker tag (invalid branch)
+        id: run
+        continue-on-error: true
+        uses: ./.github/actions/get-branch-docker-tag
+        with:
+          branch: this-branch-does-not-exist-xyz
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify the action failed
+        run: |
+          if [ "${{ steps.run.outcome }}" != "failure" ]; then
+            echo "Expected failure for a non-existent branch, outcome=${{ steps.run.outcome }}"; exit 1
+          fi
+
+  # An invalid max_depth must fail fast (input validation).
+  invalid-max-depth:
+    name: "Invalid max_depth fails"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve docker tag (invalid max_depth)
+        id: run
+        continue-on-error: true
+        uses: ./.github/actions/get-branch-docker-tag
+        with:
+          branch: main
+          max_depth: '0'
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify the action failed
+        run: |
+          if [ "${{ steps.run.outcome }}" != "failure" ]; then
+            echo "Expected failure for max_depth=0, outcome=${{ steps.run.outcome }}"; exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ jobs:
 
 ### Behavior
 - Walks the branch's commit history newest-first; for each commit it reads `<version>` from `openapi-specs/schema.json` at that commit and checks whether `semitechnologies/weaviate:<version>-<short-sha>` exists in the registry, returning the first one that does.
+- Only commits on the branch's own version line are considered (for `stable/vX.Y`, the `X.Y` line; for `main`/other, the tip's major.minor); off-line ancestor commits are skipped so a fallback can't return e.g. a `1.35.x` image for `stable/v1.36`.
 - Uses the registry's **exact-tag** endpoint (reliable) rather than tag listings (which time out for common prefixes), and anchors to the branch's own commits so the result is branch-precise (the bare semver tag alone collides across branches that share a version).
 - Fails (exit 1) if `max_depth` is not an integer between 1 and 100, if the branch is empty or does not exist, or if no published image is found within `max_depth` commits.
 - No Docker auth is required (public repo); a `gh_token` is recommended only to avoid GitHub commits-API rate limits.

--- a/README.md
+++ b/README.md
@@ -318,3 +318,90 @@ jobs:
 - `main` (when `include_main: 'true'`) is always appended last, since it is ahead of every release branch.
 - The action fails (exit 1) if `count` is not a positive integer, or if no matching version branches are found — preventing a silently empty matrix.
 
+## get-branch-docker-tag
+
+### Description
+Resolves a Weaviate git branch (`main` or `stable/vX.Y`) to the **latest available** multi-arch Docker tag published to Docker Hub (e.g. `1.38.0-rc.1-8269596`). Weaviate's CI publishes a multi-arch tag `<version>-<short-sha>` for built commits only, so the newest commit on a branch frequently has no image yet — this action walks back the branch history and returns the most recent commit that *does* have a published image, guaranteeing the returned tag is pullable.
+
+Pairs with [`get-latest-branches`](#get-latest-branches): use that to list the branches, then this to resolve each branch to its newest image.
+
+### Inputs
+- `branch` (required): Git branch to resolve, e.g. `main` or `stable/v1.38` (as emitted by `get-latest-branches`). A leading `refs/heads/` is stripped.
+- `repository` (optional): GitHub repository (`owner/name`) whose commits and `openapi-specs/schema.json` are read. Default: `weaviate/weaviate`.
+- `registry` (optional): Docker Hub repository (`namespace/name`) whose tags are checked. Default: `semitechnologies/weaviate`.
+- `gh_token` (optional): GitHub token for the commits API (avoids rate limits). Recommended. Default: `''`.
+- `max_depth` (optional): How many commits back from the branch tip to search before failing. Default: `30`.
+
+### Outputs
+- `docker_tag`: Latest available multi-arch semver tag, e.g. `1.38.0-rc.1-8269596`.
+- `version`: The version part of the tag, e.g. `1.38.0-rc.1`.
+- `sha`: 7-char short commit the image was built from, e.g. `8269596`.
+- `commit`: Full 40-char commit SHA the image was built from.
+- `is_fallback`: `'true'` if the branch tip had no published image and an older commit was used, otherwise `'false'`.
+- `commits_behind`: How many commits behind the branch tip the resolved image is (`0` = the tip itself).
+
+### Usage
+
+#### Single branch
+```yaml
+name: Resolve Latest Image
+on: [push]
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Resolve latest image for main
+        id: tag
+        uses: weaviate/github-common-actions/.github/actions/get-branch-docker-tag@main
+        with:
+          branch: main
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull it
+        run: |
+          echo "Pulling semitechnologies/weaviate:${{ steps.tag.outputs.docker_tag }}"
+          docker pull "semitechnologies/weaviate:${{ steps.tag.outputs.docker_tag }}"
+```
+
+#### Composed with `get-latest-branches` (matrix over the newest branches)
+```yaml
+jobs:
+  branches:
+    runs-on: ubuntu-latest
+    outputs:
+      branches_json: ${{ steps.b.outputs.branches_json }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: b
+        uses: weaviate/github-common-actions/.github/actions/get-latest-branches@main
+        with:
+          count: '3'
+          include_main: 'true'
+
+  resolve:
+    needs: branches
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJSON(needs.branches.outputs.branches_json) }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: tag
+        uses: weaviate/github-common-actions/.github/actions/get-branch-docker-tag@main
+        with:
+          branch: ${{ matrix.branch }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+      - run: echo "${{ matrix.branch }} -> ${{ steps.tag.outputs.docker_tag }} (behind ${{ steps.tag.outputs.commits_behind }})"
+```
+
+### Behavior
+- Walks the branch's commit history newest-first; for each commit it reads `<version>` from `openapi-specs/schema.json` at that commit and checks whether `semitechnologies/weaviate:<version>-<short-sha>` exists in the registry, returning the first one that does.
+- Uses the registry's **exact-tag** endpoint (reliable) rather than tag listings (which time out for common prefixes), and anchors to the branch's own commits so the result is branch-precise (the bare semver tag alone collides across branches that share a version).
+- Fails (exit 1) if `max_depth` is not a positive integer, if the branch does not exist, or if no published image is found within `max_depth` commits.
+- No Docker auth is required (public repo); a `gh_token` is recommended only to avoid GitHub commits-API rate limits.
+

--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ jobs:
 - Walks the branch's commit history newest-first; for each commit it reads `<version>` from `openapi-specs/schema.json` at that commit and checks whether `semitechnologies/weaviate:<version>-<short-sha>` exists in the registry, returning the first one that does.
 - Only commits on the branch's own version line are considered (for `stable/vX.Y`, the `X.Y` line; for `main`/other, the tip's major.minor); off-line ancestor commits are skipped so a fallback can't return e.g. a `1.35.x` image for `stable/v1.36`.
 - Uses the registry's **exact-tag** endpoint (reliable) rather than tag listings (which time out for common prefixes), and anchors to the branch's own commits so the result is branch-precise (the bare semver tag alone collides across branches that share a version).
-- Fails (exit 1) if `max_depth` is not an integer between 1 and 100, if the branch is empty or does not exist, or if no published image is found within `max_depth` commits.
+- Fails (exit 1) if `max_depth` is not an integer between 1 and 100, if `repository`/`registry` is empty, if the branch is empty or does not exist, or if no published image is found within `max_depth` commits.
+- Fails closed: if Docker Hub returns an ambiguous status (e.g. 5xx/429/000) for a candidate tag after retries, the action errors rather than treating it as "missing" and silently falling back to an older image.
 - No Docker auth is required (public repo); a `gh_token` is recommended only to avoid GitHub commits-API rate limits.
 

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Pairs with [`get-latest-branches`](#get-latest-branches): use that to list the b
 - `repository` (optional): GitHub repository (`owner/name`) whose commits and `openapi-specs/schema.json` are read. Default: `weaviate/weaviate`.
 - `registry` (optional): Docker Hub repository (`namespace/name`) whose tags are checked. Default: `semitechnologies/weaviate`.
 - `gh_token` (optional): GitHub token for the commits API (avoids rate limits). Recommended. Default: `''`.
-- `max_depth` (optional): How many commits back from the branch tip to search before failing. Default: `30`.
+- `max_depth` (optional): How many commits back from the branch tip to search before failing. Must be `1`-`100` (the GitHub commits API caps a page at 100). Default: `30`.
 
 ### Outputs
 - `docker_tag`: Latest available multi-arch semver tag, e.g. `1.38.0-rc.1-8269596`.
@@ -402,6 +402,6 @@ jobs:
 ### Behavior
 - Walks the branch's commit history newest-first; for each commit it reads `<version>` from `openapi-specs/schema.json` at that commit and checks whether `semitechnologies/weaviate:<version>-<short-sha>` exists in the registry, returning the first one that does.
 - Uses the registry's **exact-tag** endpoint (reliable) rather than tag listings (which time out for common prefixes), and anchors to the branch's own commits so the result is branch-precise (the bare semver tag alone collides across branches that share a version).
-- Fails (exit 1) if `max_depth` is not a positive integer, if the branch does not exist, or if no published image is found within `max_depth` commits.
+- Fails (exit 1) if `max_depth` is not an integer between 1 and 100, if the branch is empty or does not exist, or if no published image is found within `max_depth` commits.
 - No Docker auth is required (public repo); a `gh_token` is recommended only to avoid GitHub commits-API rate limits.
 


### PR DESCRIPTION
## Motivation

Several Weaviate CI/test pipelines need to pull "the newest image for branch X" (e.g. `main` or a `stable/vX.Y` line) but can't just construct the tag from the branch tip: Weaviate's CI (`ci/push_docker.sh`) only publishes a multi-arch `<version>-<short-sha>` image for *built* commits, so the HEAD of a branch frequently has no image yet. Today pipelines reinvent some flavor of "guess the tag and hope it's pullable," which is fragile. This action centralizes that resolution and **guarantees the returned tag actually exists in the registry**.

## Approach

Resolution is **git-anchored**, not registry-listing-based. The action walks the branch's commit history newest-first; for each commit it reads `<version>` from `openapi-specs/schema.json` at that commit, constructs the candidate tag `<version>-<short-sha>`, and probes Docker Hub's **exact-tag** endpoint (`/tags/<tag>`). The first commit with a published image wins.

Two design decisions, both documented inline in `action.yml`:

- **Exact-tag probe over tag listing.** Docker Hub's `/tags?name=<prefix>` listing endpoint is slow/unreliable (repeated `504`/connection timeouts observed) for common version prefixes like `main-`; the single-tag `/tags/<tag>` endpoint is reliable. This was discovered during implementation and is the reason the design is git-anchored rather than "list the branch's tags and pick the newest."
- **Anchoring to the branch's own commits** keeps the result branch-precise. The bare semver tag (e.g. `1.38.0-rc.1-<sha>`) collides across branches that share a version — `main` and a freshly-cut `stable/v1.38` are both `1.38.0-rc.1`. Walking *this* branch's history is what makes the answer unambiguous.

The walk is bounded by `max_depth` (default 30) and surfaces how far it fell back via `is_fallback` / `commits_behind`, so callers can tell whether they got the tip's image or an older one. (Built commits are sparse — only ~1 in 7 `main` commits has an image — so falling back a few commits is the normal case, not an error.)

## Key areas for review

- **Input handling** — inputs are passed via `env:` rather than interpolated into the `run:` body, so branch/repo/registry values can't break out of the shell. Worth confirming nothing re-introduces `${{ }}` inside `run:`.
- **The walk loop + `set -e` discipline** — the schema fetch uses `|| ... continue` and the Hub probe uses `|| true` so a transient non-200 (incl. curl's connection-error exit) doesn't abort the whole walk; only an explicit `200` is treated as "exists." Verify a network blip on one commit can't cause a false "no image found."
- **Input validation** — positive-integer `max_depth`, non-empty `branch`.

## Risks and mitigations

- **Transient registry/API errors → false negative.** Mitigated with `curl --retry 3 --retry-delay 2` on the GitHub/schema/Hub calls and a `--max-time 30` cap; only an explicit `200` counts as "exists," and only a hard failure of the commits API aborts. If every probe within `max_depth` failed transiently, the action fails closed (exit 1) rather than returning a wrong tag — the safe direction.
- **GitHub commits-API rate limiting** on unauthenticated runs. Mitigated by the optional (recommended) `gh_token`; the test workflow passes `${{ secrets.GITHUB_TOKEN }}`.
- **Branch tip more than `max_depth` commits ahead of the last built commit.** Fails loudly with a clear error rather than returning stale data; `max_depth` is tunable per caller.

## Testing

`get-branch-docker-tag-test.yml` runs four jobs against the real `weaviate/weaviate` repo and `semitechnologies/weaviate` registry. Assertions are structural (no hardcoded versions) so the suite doesn't rot as new releases ship:

- **`main`** — resolved tag matches `<major.minor.patch>[-prerelease]-<7hex>`; `sha` is the 7-char prefix of the 40-char `commit`; `docker_tag == version-sha`; `is_fallback`/`commits_behind` are mutually consistent; and — the core guarantee — the tag returns **HTTP 200** from the registry (actually pullable).
- **`stable/v1.36`** — verifies a mature stable branch resolves to its *own* `1.36.x` version line (catches cross-branch version collisions) and is pullable.
- **`invalid-branch`** — a non-existent branch must fail (commits API 404).
- **`invalid-max-depth`** — `max_depth: '0'` must fail fast via input validation.

Also exercised locally end-to-end before committing, including a forced fallback (walking past 6 unbuilt `main` commits to land on `1.38.0-rc.1-2f978bd` at `commits_behind=6`) and the depth-exhausted error path.

## Companion PR

This action is designed to compose with **`get-latest-branches`** (added in #14, not yet merged): list the latest branches there, then resolve each to its newest image here. The README's matrix example uses `get-latest-branches`' `branches_json` output. Because #14 isn't on `main` yet, this PR's test workflow deliberately **does not** include a cross-action "compose" job (it would reference an action that doesn't exist on `main` yet, turning CI red); composition is covered by the `main`/`stable` jobs (which prove "given a branch string, resolve a live tag") and documented in the README. Once both merge, they compose as shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
