### PR TITLE
Add optional log_dir input to capture-logs action

### DIFF
--- a/.github/actions/capture-logs/action.yml
+++ b/.github/actions/capture-logs/action.yml
@@ -55,9 +55,11 @@ runs:
       env:
         LOG_DIR: ${{ inputs.log_dir }}
         LOG_FILE_NAME: ${{ inputs.log_file_name }}
+        NAMESPACE: ${{ inputs.namespace }}
+        SELECTOR: ${{ inputs.selector }}
       run: |
-        mkdir -p "${LOG_DIR}"
-        stern --namespace ${{ inputs.namespace }} --selector ${{ inputs.selector }} > "${LOG_DIR}/${LOG_FILE_NAME}" &
+        mkdir -p -- "${LOG_DIR}"
+        stern --namespace "${NAMESPACE}" --selector "${SELECTOR}" > "${LOG_DIR}/${LOG_FILE_NAME}" &
 
     - name: Start Docker logs
       if: inputs.action == 'start' && inputs.type == 'docker'
@@ -65,17 +67,18 @@ runs:
       env:
         LOG_DIR: ${{ inputs.log_dir }}
         LOG_FILE_NAME: ${{ inputs.log_file_name }}
+        DOCKER_COMPOSE_FILE: ${{ inputs.docker_compose_file }}
       run: |
         # Verify docker-compose file exists
-        if [ ! -f "${{ inputs.docker_compose_file }}" ]; then
-          echo "Error: Docker compose file not found at ${{ inputs.docker_compose_file }}"
+        if [ ! -f "${DOCKER_COMPOSE_FILE}" ]; then
+          echo "Error: Docker compose file not found at ${DOCKER_COMPOSE_FILE}"
           exit 1
         fi
 
-        mkdir -p "${LOG_DIR}"
+        mkdir -p -- "${LOG_DIR}"
 
         # Start docker compose logs in background
-        docker compose -f ${{ inputs.docker_compose_file }} logs -f > "${LOG_DIR}/${LOG_FILE_NAME}" &
+        docker compose -f "${DOCKER_COMPOSE_FILE}" logs -f > "${LOG_DIR}/${LOG_FILE_NAME}" &
         echo $! > /tmp/docker_logs_pid
 
     - name: Stop Kubernetes logs

--- a/.github/actions/capture-logs/action.yml
+++ b/.github/actions/capture-logs/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: 'Name of the log file to capture'
     required: false
     default: 'weaviate_pods.log'
+  log_dir:
+    description: 'Directory where the log file will be written (created if it does not exist)'
+    required: false
+    default: '/tmp'
   namespace:
     description: 'Kubernetes namespace to capture logs from (only used when type=kubernetes)'
     required: false
@@ -48,21 +52,30 @@ runs:
     - name: Start stern logs for Kubernetes
       if: inputs.action == 'start' && inputs.type == 'kubernetes'
       shell: bash
+      env:
+        LOG_DIR: ${{ inputs.log_dir }}
+        LOG_FILE_NAME: ${{ inputs.log_file_name }}
       run: |
-        stern --namespace ${{ inputs.namespace }} --selector ${{ inputs.selector }} > /tmp/${{ inputs.log_file_name }} &
+        mkdir -p "${LOG_DIR}"
+        stern --namespace ${{ inputs.namespace }} --selector ${{ inputs.selector }} > "${LOG_DIR}/${LOG_FILE_NAME}" &
 
     - name: Start Docker logs
       if: inputs.action == 'start' && inputs.type == 'docker'
       shell: bash
+      env:
+        LOG_DIR: ${{ inputs.log_dir }}
+        LOG_FILE_NAME: ${{ inputs.log_file_name }}
       run: |
         # Verify docker-compose file exists
         if [ ! -f "${{ inputs.docker_compose_file }}" ]; then
           echo "Error: Docker compose file not found at ${{ inputs.docker_compose_file }}"
           exit 1
         fi
-        
+
+        mkdir -p "${LOG_DIR}"
+
         # Start docker compose logs in background
-        docker compose -f ${{ inputs.docker_compose_file }} logs -f > /tmp/${{ inputs.log_file_name }} &
+        docker compose -f ${{ inputs.docker_compose_file }} logs -f > "${LOG_DIR}/${LOG_FILE_NAME}" &
         echo $! > /tmp/docker_logs_pid
 
     - name: Stop Kubernetes logs

--- a/.github/workflows/capture-logs-test.yml
+++ b/.github/workflows/capture-logs-test.yml
@@ -76,6 +76,25 @@ jobs:
           pgrep -f "stern --namespace weaviate --selector app=weaviate" > /dev/null
           test -f /tmp/test_stern_k8s_custom.log
 
+      - name: Stop stern before custom log directory test
+        uses: ./.github/actions/capture-logs
+        with:
+          action: 'stop'
+          type: 'kubernetes'
+
+      - name: Test Kubernetes mode with custom log directory
+        uses: ./.github/actions/capture-logs
+        with:
+          action: 'start'
+          log_file_name: 'test_stern_k8s_dir.log'
+          log_dir: '${{ runner.temp }}/weaviate-logs'
+          type: 'kubernetes'
+
+      - name: Verify logs are captured in custom directory
+        run: |
+          pgrep -f "stern --namespace weaviate --selector app=weaviate" > /dev/null
+          test -f "${{ runner.temp }}/weaviate-logs/test_stern_k8s_dir.log"
+
       - name: Archive Kubernetes logs
         uses: actions/upload-artifact@v4
         with:
@@ -83,6 +102,7 @@ jobs:
           path: |
             /tmp/test_stern_k8s.log
             /tmp/test_stern_k8s_custom.log
+            ${{ runner.temp }}/weaviate-logs/test_stern_k8s_dir.log
           if-no-files-found: error
 
       - name: Final cleanup
@@ -142,11 +162,37 @@ jobs:
         run: |
           ! pgrep -f "docker compose.*logs -f" > /dev/null
 
+      - name: Test Docker mode with custom log directory
+        uses: ./.github/actions/capture-logs
+        with:
+          action: 'start'
+          log_file_name: 'test_docker_dir.log'
+          log_dir: '${{ runner.temp }}/docker-logs'
+          type: 'docker'
+          docker_compose_file: 'test-docker-compose.yml'
+
+      - name: Verify Docker logs in custom directory
+        run: |
+          test -f "${{ runner.temp }}/docker-logs/test_docker_dir.log"
+          pgrep -f "docker compose.*logs -f" > /dev/null
+
+      - name: Stop Docker logs from custom directory test
+        uses: ./.github/actions/capture-logs
+        with:
+          action: 'stop'
+          type: 'docker'
+
+      - name: Verify custom directory Docker logs stopped
+        run: |
+          ! pgrep -f "docker compose.*logs -f" > /dev/null
+
       - name: Archive Docker logs
         uses: actions/upload-artifact@v4
         with:
           name: docker-logs
-          path: /tmp/test_docker.log
+          path: |
+            /tmp/test_docker.log
+            ${{ runner.temp }}/docker-logs/test_docker_dir.log
           if-no-files-found: error
 
       - name: Cleanup Docker services

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Captures and manages logs from either Kubernetes pods or Docker containers. For 
 - `stern_version` (optional): The version of stern to install when using Kubernetes mode. Default: '1.30.0'
 - `action` (optional): The action to perform. Options: 'start' or 'stop'. Default: 'start'
 - `log_file_name` (optional): Name of the file where logs will be captured. Default: 'weaviate_pods.log'
+- `log_dir` (optional): Directory where the log file will be written. The directory is created if it does not exist. Default: '/tmp'
 - `namespace` (optional): Kubernetes namespace to capture logs from (only used when type=kubernetes). Default: 'weaviate'
 - `selector` (optional): Kubernetes label selector for pods (only used when type=kubernetes). Default: 'app=weaviate'
 - `type` (optional): Type of logging to perform. Options: 'kubernetes' or 'docker'. Default: 'kubernetes'
@@ -234,7 +235,7 @@ jobs:
 
 ### Notes
 - The action runs in the background and continues capturing logs until explicitly stopped
-- Logs are written to `/tmp/{log_file_name}`
+- Logs are written to `{log_dir}/{log_file_name}` (defaults to `/tmp/{log_file_name}`)
 - For Kubernetes mode, stern is used to capture logs from multiple pods simultaneously
 - For Docker mode, docker compose logs is used to capture logs from all services
 - Always use the stop action in a cleanup step (with `if: always()`) to ensure logs are properly stopped

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ This action runs using `composite` with the following steps:
 Captures and manages logs from either Kubernetes pods or Docker containers. For Kubernetes, it uses stern to capture logs from pods matching specific labels. For Docker, it uses docker compose logs to capture logs from all services defined in a docker-compose file.
 
 ### Inputs
-- `stern_version` (optional): The version of stern to install when using Kubernetes mode. Default: '1.30.0'
+- `stern_version` (optional): The version of stern to install when using Kubernetes mode. Default: '1.34.0'
 - `action` (optional): The action to perform. Options: 'start' or 'stop'. Default: 'start'
 - `log_file_name` (optional): Name of the file where logs will be captured. Default: 'weaviate_pods.log'
 - `log_dir` (optional): Directory where the log file will be written. The directory is created if it does not exist. Default: '/tmp'
@@ -170,7 +170,7 @@ jobs:
       - name: Start capturing Kubernetes logs
         uses: weaviate/github-common-actions/.github/actions/capture-logs@main
         with:
-          stern_version: '1.30.0'
+          stern_version: '1.34.0'
           action: 'start'
           log_file_name: 'weaviate.log'
           namespace: 'weaviate'


### PR DESCRIPTION
### Motivation

The `capture-logs` action hardcodes `/tmp` as the destination for captured logs. Workflows that want logs somewhere collectable-by-convention (e.g. `${{ runner.temp }}`, a workspace subdirectory shared with other artifact steps, or a self-hosted runner where `/tmp` is unsuitable) currently can't redirect the output. This adds an optional `log_dir` input while keeping the existing behavior for all current callers.

### Approach

- `log_dir` defaults to `/tmp`, so the change is fully backward compatible — no existing workflow needs updating.
- The directory is created with `mkdir -p` before starting the log stream, so callers can point at not-yet-existing paths like `${{ runner.temp }}/weaviate-logs` without a preparatory step.
- The new path components are passed to the scripts via `env:` (`LOG_DIR`, `LOG_FILE_NAME`) and quoted in the redirect, rather than interpolated inline with `${{ }}` — this handles paths containing spaces and avoids shell-injection footguns for the user-controlled values.
- The `stop` action is untouched: it kills by process (`pkill stern` / pid file at `/tmp/docker_logs_pid`) and never references the log path, so no path needs to be threaded through to it.

### Risks and mitigations

- **Breaking existing consumers**: mitigated by the `/tmp` default — the resolved path is byte-identical to the old behavior when `log_dir` is not set.
- **Unwritable custom directory**: `mkdir -p` fails the start step loudly instead of silently producing no logs.

### Testing

Extended `.github/workflows/capture-logs-test.yml` with custom-directory scenarios for both modes:

- **Kubernetes**: starts stern with `log_dir: ${{ runner.temp }}/weaviate-logs`, verifies the stern process is running and the log file exists at the custom path, then stops it.
- **Docker**: same flow with `log_dir: ${{ runner.temp }}/docker-logs`, including verifying the stop action still terminates the background `docker compose logs` process started with a custom directory.
- Both jobs upload the custom-directory logs as artifacts with `if-no-files-found: error`, so a missing file fails CI rather than passing silently. Default-path (`/tmp`) scenarios remain in the workflow, covering backward compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)